### PR TITLE
Replace old links to example files

### DIFF
--- a/keras/keras_integration.py
+++ b/keras/keras_integration.py
@@ -11,7 +11,7 @@ You can run this example as follows:
 
 For a similar Optuna example that demonstrates Keras without a pruner on a regression dataset,
 see the following link:
-    https://github.com/optuna/optuna/blob/master/examples/mlflow/keras_mlflow.py
+    https://github.com/optuna/optuna-examples/blob/main/mlflow/keras_mlflow.py
 
 """
 import urllib

--- a/visualization/plot_study.ipynb
+++ b/visualization/plot_study.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/optuna/optuna/blob/master/examples/visualization/plot_study.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://github.com/optuna/optuna-examples/blob/main/visualization/plot_study.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
## Motivation

I found links to `optuna/examples` that will be removed soon. 

## Description of the changes

Replace the URLs. As a result, we do not have links to files in `optuna/examples` anymore as follows.

```bash
grep  '/examples/' -r .
./allennlp/allennlp_jsonnet.py:            " https://github.com/optuna/optuna/blob/v2.5.0/examples/allennlp/allennlp_jsonnet.py"
./allennlp/allennlp_simple.py:            " https://github.com/optuna/optuna/blob/v2.5.0/examples/allennlp/allennlp_simple.py"
./haiku/haiku_simple.py:The example code is based on https://github.com/deepmind/dm-haiku/blob/master/examples/mnist.py
```