### PR TITLE
Avoid `tensorflow` 2.5.0

### DIFF
--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,4 +1,6 @@
 keras
 optuna
-tensorflow
+# TODO(nzw): Remove the version constraint after resolving the issue
+# https://github.com/keras-team/keras/issues/14632
+tensorflow<2.5.0
 tensorflow-datasets


### PR DESCRIPTION
## Motivation

#12 is blocked by a CI error that is caused by the combination of TensorFlow 2.5 and Keras.

## Description of the changes
As in https://github.com/optuna/optuna/pull/2674, this PR adds the constraint of the TensorFlow version: `tensorflow<2.5.0`.
