### PR TITLE
Avoid tensorflow 2.5

### DIFF
--- a/mlflow/requirements.txt
+++ b/mlflow/requirements.txt
@@ -2,4 +2,6 @@ keras
 mlflow
 optuna
 scikit-learn
-tensorflow
+# TODO(hvy): Remove the version constraint after resolving the issue
+# https://github.com/keras-team/keras/issues/14632
+tensorflow<2.5.0


### PR DESCRIPTION
Similar fix to https://github.com/optuna/optuna-examples/pull/13. 

Daily CI breakage that'll be fixed: https://github.com/optuna/optuna-examples/runs/2611793257?check_suite_focus=true