### PR TITLE
Use only one GPU for PyTorchLightning example by default 

### DIFF
--- a/pytorch/pytorch_lightning_simple.py
+++ b/pytorch/pytorch_lightning_simple.py
@@ -134,7 +134,7 @@ def objective(trial: optuna.trial.Trial) -> float:
         limit_val_batches=PERCENT_VALID_EXAMPLES,
         checkpoint_callback=False,
         max_epochs=EPOCHS,
-        gpus=-1 if torch.cuda.is_available() else None,
+        gpus=1 if torch.cuda.is_available() else None,
         callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc")],
     )
     hyperparameters = dict(n_layers=n_layers, dropout=dropout, output_dims=output_dims)


### PR DESCRIPTION
## Motivation

The current example uses all GPUs if PyTorchLightning works on a machine with multiple GPUs by default. However, the example does not work properly as reported in https://github.com/optuna/optuna-examples/issues/14.

## Changes

By default, the example uses only one GPU for optimisation.  