### PR TITLE
Replace monitor value with accuracy

### DIFF
--- a/fastai/fastaiv1_simple.py
+++ b/fastai/fastaiv1_simple.py
@@ -15,8 +15,8 @@ argument.
 """
 
 import argparse
-import urllib
 from functools import partial
+import urllib
 
 import optuna
 from optuna.integration import FastAIV1PruningCallback

--- a/fastai/fastaiv1_simple.py
+++ b/fastai/fastaiv1_simple.py
@@ -15,8 +15,8 @@ argument.
 """
 
 import argparse
-from functools import partial
 import urllib
+from functools import partial
 
 import optuna
 from optuna.integration import FastAIV1PruningCallback
@@ -70,11 +70,11 @@ def objective(trial):
         model,
         silent=True,
         metrics=[vision.accuracy],
-        callback_fns=[partial(FastAIV1PruningCallback, trial=trial, monitor="valid_loss")],
+        callback_fns=[partial(FastAIV1PruningCallback, trial=trial, monitor="accuracy")],
     )
     learn.fit(EPOCHS)
 
-    return learn.validate()[-1].item()
+    return learn.recorder.metrics[0][0].item()
 
 
 if __name__ == "__main__":

--- a/fastai/fastaiv1_simple.py
+++ b/fastai/fastaiv1_simple.py
@@ -74,7 +74,7 @@ def objective(trial):
     )
     learn.fit(EPOCHS)
 
-    return learn.recorder.metrics[0][0].item()
+    return learn.recorder.metrics[-1][0].item()
 
 
 if __name__ == "__main__":

--- a/fastai/fastaiv2_simple.py
+++ b/fastai/fastaiv2_simple.py
@@ -77,7 +77,7 @@ def objective(trial):
         model,
         metrics=[accuracy],
         # You could as FastAIPruningCallback in the fit function
-        cbs=FastAIPruningCallback(trial),
+        cbs=FastAIPruningCallback(trial, monitor="accuracy"),
     )
 
     # See https://forums.fast.ai/t/how-to-diable-progress-bar-completely/65249/3
@@ -86,7 +86,7 @@ def objective(trial):
         with learn.no_logging():
             learn.fit(EPOCHS)
 
-    return learn.validate()[-1]
+    return learn.recorder.metrics[0].value.item()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna-examples/issues/31. More precisely, in the current example files, fastAI's callback monitor is validation loss by default, however, the study direction is `maximization`. 


## Description of the changes
<!-- Describe the changes in this PR. -->

Use `accuracy` for monitor value and remove `validate` since the validation accuracy is already stored.