### PR TITLE
Fix typo in Dask-ML GitHub Action workflow

### DIFF
--- a/.github/workflows/dask_ml.yml
+++ b/.github/workflows/dask_ml.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - 'dask_ml/**'
-      - '.github/workflows/dask.yml'
+      - '.github/workflows/dask_ml.yml'
 
 jobs:
   examples:


### PR DESCRIPTION
It looks like there's a small typo where `.github/workflows/dask.yml` (which doesn't exist) is being used instead of `.github/workflows/dask_ml.yml`. This PR updates `dask.yml` -> `dask_ml.yml`