### PR TITLE
Replace deprecated argument `lr` with `learning_rate` in tf.keras

### DIFF
--- a/mlflow/keras_mlflow.py
+++ b/mlflow/keras_mlflow.py
@@ -51,7 +51,7 @@ def create_model(num_features, trial):
     model.add(Dense(1, kernel_initializer="normal", activation="linear"))
 
     optimizer = SGD(
-        lr=trial.suggest_float("lr", 1e-5, 1e-1, log=True),
+        learning_rate=trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True),
         momentum=trial.suggest_float("momentum", 0.0, 1.0),
     )
     model.compile(loss="mean_squared_error", optimizer=optimizer)

--- a/tfkeras/tfkeras_integration.py
+++ b/tfkeras/tfkeras_integration.py
@@ -60,7 +60,7 @@ def eval_dataset():
 def create_model(trial):
 
     # Hyperparameters to be tuned by Optuna.
-    lr = trial.suggest_float("lr", 1e-4, 1e-1, log=True)
+    learning_rate = trial.suggest_float("learning_rate", 1e-4, 1e-1, log=True)
     momentum = trial.suggest_float("momentum", 0.0, 1.0)
     units = trial.suggest_categorical("units", [32, 64, 128, 256, 512])
 
@@ -72,7 +72,9 @@ def create_model(trial):
 
     # Compile model.
     model.compile(
-        optimizer=tf.keras.optimizers.SGD(lr=lr, momentum=momentum, nesterov=True),
+        optimizer=tf.keras.optimizers.SGD(
+            learning_rate=learning_rate, momentum=momentum, nesterov=True
+        ),
         loss="sparse_categorical_crossentropy",
         metrics=["accuracy"],
     )

--- a/tfkeras/tfkeras_simple.py
+++ b/tfkeras/tfkeras_simple.py
@@ -60,9 +60,11 @@ def objective(trial):
     model.add(Dense(CLASSES, activation="softmax"))
 
     # We compile our model with a sampled learning rate.
-    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
+    learning_rate = trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True)
     model.compile(
-        loss="sparse_categorical_crossentropy", optimizer=RMSprop(lr=lr), metrics=["accuracy"]
+        loss="sparse_categorical_crossentropy",
+        optimizer=RMSprop(learning_rate=learning_rate),
+        metrics=["accuracy"],
     )
 
     model.fit(


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Optimizers' `lr` argument is deprecated in tf.keras as reported in https://github.com/optuna/optuna-examples/pull/47#discussion_r687619313.

## Description of the changes
<!-- Describe the changes in this PR. -->

Replace `lr` with `learning_rate`.