### PR TITLE
Add python 3.9 to CI yaml files

### DIFF
--- a/.github/workflows/allennlp.yml
+++ b/.github/workflows/allennlp.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tensorboard.yml
+++ b/.github/workflows/tensorboard.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - 'tensorboard/**'
-      - '.github/workflows/tensorbloard.yml'
+      - '.github/workflows/tensorboard.yml'
 
 jobs:
   examples:

--- a/.github/workflows/tensorboard.yml
+++ b/.github/workflows/tensorboard.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I realised that we can test python 3.9 for several examples. 
See also https://github.com/optuna/optuna/issues/2034.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add python 3.9 to their version matrix.
- fix typo in `tensorboard.yml` to run tensorboard's CI.

---

I suppose we cannot add python 3.9 to their version matrix for following examples:

```bash
grep  -i "3.8]" -r .
./keras.yml:        python-version: [3.6, 3.7, 3.8] # tensorflow < 2.5.0 does not support python 3.9
./fastai.yml:        python-version: [3.6, 3.7, 3.8] # fastai does not support pyhon 3.9
```
