### PR TITLE
Remove deprecated warning message in lightgbm

### DIFF
--- a/lightgbm/lightgbm_integration.py
+++ b/lightgbm/lightgbm_integration.py
@@ -42,9 +42,7 @@ def objective(trial):
 
     # Add a callback for pruning.
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
-    gbm = lgb.train(
-        param, dtrain, valid_sets=[dvalid], verbose_eval=False, callbacks=[pruning_callback]
-    )
+    gbm = lgb.train(param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback])
 
     preds = gbm.predict(valid_x)
     pred_labels = np.rint(preds)

--- a/lightgbm/lightgbm_tuner_cv.py
+++ b/lightgbm/lightgbm_tuner_cv.py
@@ -6,6 +6,8 @@ In this example, we optimize the cross-validated log loss of cancer detection.
 """
 import optuna.integration.lightgbm as lgb
 
+from lightgbm import early_stopping
+from lightgbm import log_evaluation
 import sklearn.datasets
 from sklearn.model_selection import KFold
 
@@ -22,7 +24,10 @@ if __name__ == "__main__":
     }
 
     tuner = lgb.LightGBMTunerCV(
-        params, dtrain, verbose_eval=100, early_stopping_rounds=100, folds=KFold(n_splits=3)
+        params,
+        dtrain,
+        folds=KFold(n_splits=3),
+        callbacks=[early_stopping(100), log_evaluation(100)],
     )
 
     tuner.run()

--- a/lightgbm/lightgbm_tuner_simple.py
+++ b/lightgbm/lightgbm_tuner_simple.py
@@ -8,6 +8,8 @@ In this example, we optimize the validation log loss of cancer detection.
 import numpy as np
 import optuna.integration.lightgbm as lgb
 
+from lightgbm import early_stopping
+from lightgbm import log_evaluation
 import sklearn.datasets
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
@@ -27,7 +29,10 @@ if __name__ == "__main__":
     }
 
     model = lgb.train(
-        params, dtrain, valid_sets=[dtrain, dval], verbose_eval=100, early_stopping_rounds=100
+        params,
+        dtrain,
+        valid_sets=[dtrain, dval],
+        callbacks=[early_stopping(100), log_evaluation(100)],
     )
 
     prediction = np.rint(model.predict(val_x, num_iteration=model.best_iteration))

--- a/lightgbm/requirements.txt
+++ b/lightgbm/requirements.txt
@@ -1,4 +1,4 @@
-lightgbm
+lightgbm>=3.3.0
 numpy
 optuna
 scikit-learn


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Resolve https://github.com/optuna/optuna-examples/issues/62

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use callback instead of deprecated arguments `verbose_eval` and `early_stopping_rounds`
- Specify lightgbm version because the callbacks have been introduced since v3.3.0.

Note that a few example codes still show warning messages because the default value of `verbose_eval` and `early_stopping_rounds` of optuna's `lightgbm.train` and `lightgbm.cv` are inconsistent with the lightgbm's ones. But https://github.com/optuna/optuna/pull/3014 will resolve this inconsistency. So a reviewer of this PR might need to wait until https://github.com/optuna/optuna/pull/3014 is merged into the master branch of optuna.