### PR TITLE
Pin `tensorflow` and `tensorflow-estimator` versions to `<2.7.0`.

### DIFF
--- a/tensorflow/requirements.txt
+++ b/tensorflow/requirements.txt
@@ -1,3 +1,5 @@
-tensorflow
+# TODO(toshihikoyanase): Remove the constraints when tensorflow 2.7.0 is released.
+tensorflow-estimator<2.7.0
+tensorflow<2.7.0
 tensorflow-datasets
 optuna


### PR DESCRIPTION
## Motivation

The CI job failed due to the error of `tf.estimator.DNNClassifier` instantiation.
This may be related to https://github.com/optuna/optuna/pull/3059.

## Description of the changes

This PR adds the version restriction to `tensorflow` and `tensorflow-estimator`.