### PR TITLE
Restrict upper version of `pytorch-lightning`.

### DIFF
--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,7 +1,9 @@
 mpi4py
 plotly
 pytorch-ignite
-pytorch-lightning>=1.0.2
+# TODO(toshihikoyanase): remove the upper version constraint when the callback supports
+# pytorch-lightning==1.5.0.
+pytorch-lightning>=1.0.2,<1.5.0
 skorch
 torch==1.8.0
 torchvision==0.9.0


### PR DESCRIPTION
## Motivation

CI failed as can be seen in https://github.com/optuna/optuna-examples/actions/runs/1421887786. It is related to https://github.com/optuna/optuna/pull/3077.

## Description of the changes

- Add the version constraint of PyTorchLightning not to use `1.5.0` or higher version.