### PR TITLE
Install latest AllenNLP

### DIFF
--- a/.github/workflows/allennlp.yml
+++ b/.github/workflows/allennlp.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/allennlp/requirements.txt
+++ b/allennlp/requirements.txt
@@ -1,3 +1,3 @@
-allennlp>=2.0.0,<2.7.0
+allennlp>=2.2.0
 numpy
 optuna


### PR DESCRIPTION
🔗 https://github.com/optuna/optuna/pull/3156

This PR updates the dependency of AllenNLP examples.
After merging this PR, `pip install -r requirements.txt` will install PyTorch v1.10.0, which drops the py36 support so I removed `3.6` from python-version in actions.
