### PR TITLE
Remove Python 3.6 from haiku's CI

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix the CI of `haiku`: https://github.com/optuna/optuna-examples/actions/runs/1841778736.

## Description of the changes
<!-- Describe the changes in this PR. -->

As in the title, Remove Python 3.6 from haiku's CI because haiku and jax have dropped Python 3.6 supports. 