### PR TITLE
Stop running jobs using TF with Python3.6

### DIFF
--- a/.github/workflows/keras.yml
+++ b/.github/workflows/keras.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/keras.yml
+++ b/.github/workflows/keras.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mlflow.yml
+++ b/.github/workflows/mlflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tensorboard.yml
+++ b/.github/workflows/tensorboard.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tfkeras.yml
+++ b/.github/workflows/tfkeras.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/keras/keras_integration.py
+++ b/keras/keras_integration.py
@@ -27,6 +27,7 @@ from keras.layers import Dense
 from keras.layers import Dropout
 from keras.models import Sequential
 from tensorflow.keras.optimizers import RMSprop
+from tensorflow.keras.utils import to_categorical
 
 
 # TODO(crcrpar): Remove the below three lines once everything is ok.
@@ -78,8 +79,8 @@ def objective(trial):
     x_valid = x_valid.reshape(10000, 784)[:N_VALID_EXAMPLES].astype("float32") / 255
 
     # Convert class vectors to binary class matrices.
-    y_train = keras.utils.to_categorical(y_train[:N_TRAIN_EXAMPLES], CLASSES)
-    y_valid = keras.utils.to_categorical(y_valid[:N_VALID_EXAMPLES], CLASSES)
+    y_train = to_categorical(y_train[:N_TRAIN_EXAMPLES], CLASSES)
+    y_valid = to_categorical(y_valid[:N_VALID_EXAMPLES], CLASSES)
 
     # Generate our trial model.
     model = create_model(trial)

--- a/keras/keras_integration.py
+++ b/keras/keras_integration.py
@@ -58,10 +58,10 @@ def create_model(trial):
     model.add(Dense(CLASSES, activation="softmax"))
 
     # We compile our model with a sampled learning rate.
-    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
+    learning_rate = trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True)
     model.compile(
         loss="categorical_crossentropy",
-        optimizer=RMSprop(lr=lr),
+        optimizer=RMSprop(learning_rate=learning_rate),
         metrics=["accuracy"],
     )
 

--- a/keras/keras_integration.py
+++ b/keras/keras_integration.py
@@ -26,6 +26,7 @@ from keras.datasets import mnist
 from keras.layers import Dense
 from keras.layers import Dropout
 from keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 
 # TODO(crcrpar): Remove the below three lines once everything is ok.
@@ -60,7 +61,7 @@ def create_model(trial):
     lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
     model.compile(
         loss="categorical_crossentropy",
-        optimizer=keras.optimizers.RMSprop(lr=lr),
+        optimizer=RMSprop(lr=lr),
         metrics=["accuracy"],
     )
 

--- a/keras/keras_simple.py
+++ b/keras/keras_simple.py
@@ -60,9 +60,11 @@ def objective(trial):
     model.add(Dense(CLASSES, activation="softmax"))
 
     # We compile our model with a sampled learning rate.
-    lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
+    learning_rate = trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True)
     model.compile(
-        loss="sparse_categorical_crossentropy", optimizer=RMSprop(lr=lr), metrics=["accuracy"]
+        loss="sparse_categorical_crossentropy",
+        optimizer=RMSprop(learning_rate=learning_rate),
+        metrics=["accuracy"],
     )
 
     model.fit(

--- a/keras/keras_simple.py
+++ b/keras/keras_simple.py
@@ -17,7 +17,7 @@ from keras.layers import Conv2D
 from keras.layers import Dense
 from keras.layers import Flatten
 from keras.models import Sequential
-from keras.optimizers import RMSprop
+from tensorflow.keras.optimizers import RMSprop
 
 
 # TODO(crcrpar): Remove the below three lines once everything is ok.

--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,4 +1,4 @@
-keras<2.6.0
+keras
 optuna
 tensorflow
 tensorflow-datasets

--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,4 +1,4 @@
 keras<2.6.0
 optuna
-tensorflow<2.5.0
+tensorflow
 tensorflow-datasets


### PR DESCRIPTION
🔗 https://github.com/optuna/optuna/pull/3296

We introduced `typing-extensions` in https://github.com/optuna/optuna/pull/3270 and dropped the Python 3.6 TensorFlow support. This PR makes our CI w/TensorFlow not trigger on Python 3.6.