### PR TITLE
Pin AllenNLP version

### DIFF
--- a/allennlp/requirements.txt
+++ b/allennlp/requirements.txt
@@ -1,6 +1,8 @@
 # TODO(HideakiImamura): Remove `nltk` after solving
 # https://github.com/allenai/allennlp/issues/5521
 nltk<3.6.6
-allennlp>=2.2.0
+# TODO(himkt): Remove upper bound constraint
+# after solving https://github.com/optuna/optuna/issues/3366
+allennlp>=2.2.0,<2.9.1
 numpy
 optuna


### PR DESCRIPTION
Same as https://github.com/optuna/optuna/pull/3367.

Pin AllenNLP version in `requirements.txt`. This restriction is needed due to https://github.com/optuna/optuna/issues/3366.
The failure in the optuna CI happened when distributed training, so the CI of optuna-examples may not observe the problem. But I introduce this change to align between them.