### PR TITLE
Stop running fastai job on py36

### DIFF
--- a/.github/workflows/fastai.yml
+++ b/.github/workflows/fastai.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/fastai.yml
+++ b/.github/workflows/fastai.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
fastai v2.5.5 is now shipped with fastcore v1.4.0, which is not compatible with Python3.6.
https://github.com/fastai/fastcore/commit/6a65a554d2df2defbe977a13eeadd53002412d14

I think it's time to drop the py36 support in fastai.

https://github.com/optuna/optuna/issues/3021

(+I added py39)