### PR TITLE
Fix version of jax

### DIFF
--- a/haiku/requirements.txt
+++ b/haiku/requirements.txt
@@ -1,3 +1,8 @@
+# TODO(himkt) Remove jax after the next version of chex is released.
+# https://github.com/google/jax/issues/10331
+# https://github.com/deepmind/chex/issues/156
+jax==0.3.6
+
 dm-haiku
 numpy
 optax

--- a/haiku/requirements.txt
+++ b/haiku/requirements.txt
@@ -1,7 +1,8 @@
-# TODO(himkt) Remove jax after the next version of chex is released.
+# TODO(himkt) Remove jax and jaxlib after the next version of chex is released.
 # https://github.com/google/jax/issues/10331
 # https://github.com/deepmind/chex/issues/156
 jax==0.3.6
+jaxlib==0.3.6
 
 dm-haiku
 numpy

--- a/haiku/requirements.txt
+++ b/haiku/requirements.txt
@@ -2,7 +2,7 @@
 # https://github.com/google/jax/issues/10331
 # https://github.com/deepmind/chex/issues/156
 jax==0.3.6
-jaxlib==0.3.6
+jaxlib==0.3.5
 
 dm-haiku
 numpy


### PR DESCRIPTION
Our CI testing haiku failed.
https://github.com/optuna/optuna-examples/actions/runs/2184509596

The problem is that `chex` uses the utility removed in `jax==0.3.7`.
It should use jax v0.3.6 until the next `chex` is released.

- https://github.com/google/jax/issues/10331
- https://github.com/deepmind/chex/issues/156