### PR TITLE
Add scikit-learn version constraint for Dask-ML

### DIFF
--- a/dask_ml/requirements.txt
+++ b/dask_ml/requirements.txt
@@ -1,3 +1,4 @@
 dask-ml
 dask[dataframe]
-scikit-learn
+# TODO(not522): Remove the constraint https://github.com/dask/dask-ml/pull/910.
+scikit-learn<1.1.0


### PR DESCRIPTION
## Motivation
The CI failed because Dask-ML does not support scikit-learn 1.1.0 yet.
https://github.com/optuna/optuna-examples/actions/runs/2314293414
It will be available next Dask-ML release. https://github.com/dask/dask-ml/pull/910

## Description of the changes
Add scikit-learn version constraint for Dask-ML
