### PR TITLE
Set version constraint of `protobuf` in PyTorch Lightning example

### DIFF
--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -3,6 +3,8 @@ plotly
 pytorch-ignite
 # todo(nzw0301): Remove the upper constraint https://github.com/optuna/optuna/issues/3418.
 pytorch-lightning>=1.5.0,<1.6.0
+# TODO(yanase): Remove protobuf after resolving https://github.com/PyTorchLightning/pytorch-lightning/issues/13159.
+protobuf<4.0.0
 skorch
 torch==1.10.0
 torchvision==0.11.1


### PR DESCRIPTION
## Motivation

See https://github.com/optuna/optuna-examples/runs/6657278286?check_suite_focus=true#step:10:74.

```console
Run python pytorch/pytorch_lightning_simple.py
Traceback (most recent call last):
  File "pytorch/pytorch_lightning_simple.py", line 1[9](https://github.com/optuna/optuna-examples/runs/6657278286?check_suite_focus=true#step:10:10), in <module>
    from optuna.integration import PyTorchLightningPruningCallback
...
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

## Description of the changes

- Install `protobuf==3.x.x`
