### PR TITLE
Introduce stale bot.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: stale
+
+on:
+  schedule:
+    - cron: '0 23 * * SUN-THU'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    if: github.repository == 'optuna/optuna-examples'
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has not seen any recent activity.'
+        stale-pr-message: 'This pull request has not seen any recent activity.'
+        close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
+        close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
+        days-before-stale: 14
+        days-before-close: 100
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        exempt-issue-labels: 'no-stale'
+        exempt-pr-labels: 'no-stale'
+        operations-per-run: 1000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,8 +18,10 @@ jobs:
         stale-pr-message: 'This pull request has not seen any recent activity.'
         close-issue-message: 'This issue was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
         close-pr-message: 'This pull request was closed automatically because it had not seen any recent activity. If you want to discuss it, you can reopen it freely.'
-        days-before-stale: 14
-        days-before-close: 100
+        days-before-issue-stale: 14
+        days-before-issue-close: 100
+        days-before-pr-stale: 7
+        days-before-pr-close: 14
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         exempt-issue-labels: 'no-stale'


### PR DESCRIPTION
## Motivation

The [optuna/optuna](https://github.com/optuna/optuna) repository employs the [actions/stale bot](https://github.com/actions/stale) to warn and close inactive issues and PRs. This PR introduce it to this repository.

## Description of the changes

- [x] Add workflow file of `actions/stale`
- [x] ~Add GITHUB_TOKEN~ (The token is automatically generated by GitHub. See [this page](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).)
- [x] Add `stale` and `no-stale` labels