### PR TITLE
Move catboost integration line to integration section from pruning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ The following example demonstrates how to implement an objective function that u
 The following example demonstrates how to implement pruning logic with Optuna.
 
 * [Simple pruning (scikit-learn)](./simple_pruning.py)
-* [Pruning for CatBoost](./catboost/catboost_pruning.py)
 
 In addition, integration modules are available for the following libraries, providing simpler interfaces to utilize pruning.
 
 * [Pruning with Catalyst integration module](./pytorch/catalyst_simple.py)
+* [Pruning with CatBoost integration module](./catboost/catboost_pruning.py)
 * [Pruning with Chainer integration module](./chainer/chainer_integration.py)
 * [Pruning with ChainerMN integration module](./chainer/chainermn_integration.py)
 * [Pruning with FastAI V1 integration module](./fastai/fastaiv1_simple.py)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

[`catboost_pruning.py`](https://github.com/optuna/optuna-examples/blob/main/catboost/catboost_pruning.py) uses catboost callback in `optuna.integrations` rather than a user-defined callback, so the current location is supposed to be inaccurate.

## Description of the changes
<!-- Describe the changes in this PR. -->

Move the line and update its explanation.