### PR TITLE
Remove deprecated warning in PyTorchLightning example

### DIFF
--- a/pytorch/pytorch_lightning_simple.py
+++ b/pytorch/pytorch_lightning_simple.py
@@ -131,7 +131,7 @@ def objective(trial: optuna.trial.Trial) -> float:
     trainer = pl.Trainer(
         logger=True,
         limit_val_batches=PERCENT_VALID_EXAMPLES,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
         max_epochs=EPOCHS,
         gpus=1 if torch.cuda.is_available() else None,
         callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc")],


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

[PL's CI](https://github.com/optuna/optuna-examples/runs/7718257131?check_suite_focus=true) says 
```
/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/pytorch_lightning/trainer/connectors/callback_connector.py:147: 
LightningDeprecationWarning: Setting  `Trainer(checkpoint_callback=False)` is deprecated in v1.5 and will be removed in v1.7. 
Please consider using `Trainer(enable_checkpointing=False)`.
```
as a warning message.

## Description of the changes
<!-- Describe the changes in this PR. -->

Replace `checkpoint_callback=False` with `enable_checkpointing=False` by following the message.
