### PR TITLE
Install `scikit-learn` instead of  `sklearn`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter  # used in quickstart.ipynb
 pandas  # used in max_trials_callback.py
 plotly  # used in quickstart.ipynb
-sklearn  # used in enqueue_trial.py and quickstart.ipynb
+scikit-learn  # used in enqueue_trial.py and quickstart.ipynb

--- a/skimage/requirements.txt
+++ b/skimage/requirements.txt
@@ -1,2 +1,2 @@
 scikit-image
-sklearn  # used in skimage_lbp_simple.py
+scikit-learn  # used in skimage_lbp_simple.py

--- a/visualization/requirements.txt
+++ b/visualization/requirements.txt
@@ -1,3 +1,3 @@
-plotly 
-sklearn
+plotly
+scikit-learn
 pandas  # used in visualization/plot_study.py


### PR DESCRIPTION
## Motivation
CI failed due to `ModuleNotFoundError: No module named 'sklearn'`.
- https://github.com/optuna/optuna-examples/actions/runs/3411459033
- https://github.com/optuna/optuna-examples/actions/runs/3411457484
- https://github.com/optuna/optuna-examples/actions/runs/3411452466

This is because `sklearn` package is newly registered to deprecate `pip install sklearn` and encourage `pip install scikit-learn`.

## Description of the changes
- Replace `sklearn` in `requirements.txt` with `scikit-learn`.