### PR TITLE
Avoid python 3.10 for chainer example

### DIFF
--- a/.github/workflows/chainer.yml
+++ b/.github/workflows/chainer.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix CI. The latest release of `setuptools==65.6.0` breaks the installation of libraries which uses `distutils`. This PR suggests the same fix as https://github.com/optuna/optuna/pull/4199. 

## Description of the changes
<!-- Describe the changes in this PR. -->
Avoid python 3.10 for chanier example.