### PR TITLE
Add NCCL support for `pytorch_distributed_simple.py`

### DIFF
--- a/pytorch/pytorch_distributed_simple.py
+++ b/pytorch/pytorch_distributed_simple.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
 
     rank = dist.get_rank()
 
-    if local_rank == 0:
+    if int(local_rank) == 0:
         # Download dataset before starting the optimization.
         datasets.FashionMNIST(DIR, train=True, download=True)
     dist.barrier()

--- a/pytorch/pytorch_distributed_simple.py
+++ b/pytorch/pytorch_distributed_simple.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
 
     rank = dist.get_rank()
 
-    if rank == 0:
+    if local_rank == 0:
         # Download dataset before starting the optimization.
         datasets.FashionMNIST(DIR, train=True, download=True)
     dist.barrier()

--- a/pytorch/pytorch_distributed_simple.py
+++ b/pytorch/pytorch_distributed_simple.py
@@ -167,8 +167,10 @@ if __name__ == "__main__":
         local_rank = int(rank) % int(perhost)
     os.environ["RANK"] = str(rank)
 
-    os.environ["MASTER_ADDR"] = "127.0.0.1"
-    os.environ["MASTER_PORT"] = "20000"
+    if os.environ("MASTER_ADDR") is None:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+    if os.environ("MASTER_PORT") is None:
+        os.environ["MASTER_PORT"] = "20000"
 
     if torch.cuda.is_available():
         dist.init_process_group("nccl")

--- a/pytorch/pytorch_distributed_simple.py
+++ b/pytorch/pytorch_distributed_simple.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
 
     if torch.cuda.is_available():
         dist.init_process_group("nccl")
-        DEVICE =  torch.device(f"cuda:{local_rank}")
+        DEVICE = torch.device(f"cuda:{local_rank}")
     else:
         dist.init_process_group("gloo")
 

--- a/pytorch/pytorch_distributed_simple.py
+++ b/pytorch/pytorch_distributed_simple.py
@@ -167,9 +167,9 @@ if __name__ == "__main__":
         local_rank = int(rank) % int(perhost)
     os.environ["RANK"] = str(rank)
 
-    if os.environ("MASTER_ADDR") is None:
+    if os.environ.get("MASTER_ADDR") is None:
         os.environ["MASTER_ADDR"] = "127.0.0.1"
-    if os.environ("MASTER_PORT") is None:
+    if os.environ.get("MASTER_PORT") is None:
         os.environ["MASTER_PORT"] = "20000"
 
     if torch.cuda.is_available():


### PR DESCRIPTION
## Motivation

Alternative approach for https://github.com/optuna/optuna-examples/pull/145.

## Description of the changes

- Use `device` argument of `optuna.integration.TorchDistributedTrial`
- Check local rank to specify CUDA device in a node
- Use `MASTER_ADDR` and `MASTER_PORT` in environment variables if exist

I confirmed that this script worked with 2 nodes.

```console
$ mpiexec -x OMP_NUM_THREADS=1 --bind-to none \
    -x MASTER_ADDR="your master address" \
    -x MASTER_PORT="your master port" \
    python pytorch/pytorch_distributed_simple.py
```

See
https://pytorch.org/docs/stable/distributed.html
