### PR TITLE
Pin numpy version to `1.23.x` for mxnet examples

### DIFF
--- a/mxnet/requirements.txt
+++ b/mxnet/requirements.txt
@@ -1,3 +1,3 @@
 mxnet
-numpy
+numpy<1.24.0
 optuna


### PR DESCRIPTION
## Motivation

The CI job of the mxnet example failed when `import mxnet`.
https://github.com/optuna/optuna-examples/actions/runs/3732572214

This is due to deprecation of `numpy.bool` from numpy==1.24.0.
https://github.com/numpy/numpy/releases/tag/v1.24.0

> The deprecation for the aliases `np.object`, `np.bool`, `np.float`, `np.complex`, `np.str`, and [`np.int`](http://np.int/) is expired (introduces NumPy 1.20). Some of these will now give a `FutureWarning` in addition to raising an error since they will be mapped to the NumPy scalars in the future.
([gh-22607](https://github.com/numpy/numpy/pull/22607))

It raises the `AttributeError` in addition to `FutureWarning`.

I guess we need to wait for the update of `mxnet` to resolve this issue.
c.f., https://github.com/apache/mxnet/blob/7d602e3b2382eb501fdeb94c4d97e652a723af11/python/mxnet/numpy/utils.py#L41

## Description of the changes

- Pin `numpy` version to 1.23.x.