### PR TITLE
Use tensorflow 2.11 syntax to fix CI error

### DIFF
--- a/tensorflow/requirements.txt
+++ b/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow-estimator
-tensorflow>=2.7.0,<2.11.0
+tensorflow>=2.11.0
 tensorflow-datasets
 optuna

--- a/tensorflow/tensorflow_eager_simple.py
+++ b/tensorflow/tensorflow_eager_simple.py
@@ -23,8 +23,8 @@ opener.addheaders = [("User-agent", "Mozilla/5.0")]
 urllib.request.install_opener(opener)
 
 
-if version.parse(tf.__version__) < version.parse("2.0.0"):
-    raise RuntimeError("tensorflow>=2.0.0 is required for this example.")
+if version.parse(tf.__version__) < version.parse("2.11.0"):
+    raise RuntimeError("tensorflow>=2.11.0 is required for this example.")
 
 N_TRAIN_EXAMPLES = 3000
 N_VALID_EXAMPLES = 1000
@@ -63,7 +63,7 @@ def create_optimizer(trial):
         kwargs["learning_rate"] = trial.suggest_float(
             "rmsprop_learning_rate", 1e-5, 1e-1, log=True
         )
-        kwargs["decay"] = trial.suggest_float("rmsprop_decay", 0.85, 0.99)
+        kwargs["weight_decay"] = trial.suggest_float("rmsprop_weight_decay", 0.85, 0.99)
         kwargs["momentum"] = trial.suggest_float("rmsprop_momentum", 1e-5, 1e-1, log=True)
     elif optimizer_selected == "Adam":
         kwargs["learning_rate"] = trial.suggest_float("adam_learning_rate", 1e-5, 1e-1, log=True)

--- a/tensorflow/tensorflow_estimator_simple.py
+++ b/tensorflow/tensorflow_estimator_simple.py
@@ -60,11 +60,11 @@ def create_optimizer(trial):
     optimizer_name = trial.suggest_categorical("optimizer", ["Adam", "SGD"])
     if optimizer_name == "Adam":
         adam_lr = trial.suggest_float("adam_lr", 1e-5, 1e-1, log=True)
-        return lambda: tf.keras.optimizers.Adam(learning_rate=adam_lr)
+        return lambda: tf.keras.optimizers.legacy.Adam(learning_rate=adam_lr)
     else:
         sgd_lr = trial.suggest_float("sgd_lr", 1e-5, 1e-1, log=True)
         sgd_momentum = trial.suggest_float("sgd_momentum", 1e-5, 1e-1, log=True)
-        return lambda: tf.keras.optimizers.SGD(learning_rate=sgd_lr, momentum=sgd_momentum)
+        return lambda: tf.keras.optimizers.legacy.SGD(learning_rate=sgd_lr, momentum=sgd_momentum)
 
 
 def create_classifier(trial):


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #149.

## Description of the changes
<!-- Describe the changes in this PR. -->

### Background

Since [tensorflow 2.11.0](https://github.com/tensorflow/tensorflow/releases), optimisers provided by "tensorflow<2.11" have moved to `tf.keras.optimizers.legacy`. As a result,  tensorflow 2.11.0 provides new optimisers API under `tensorflow.keras.optimizers`.

### `tensorflow/tensorflow_eager_simple.py`

This code uses `tf.keras.optimizers`, so we need to use the new API. Specifically, I'd like to suggest replacing `decay` with `weight_decay` for rmsprop optimiser.

### `tensorflow/tensorflow_estimator_simple.py`

[`tf.estimator.DNNClassifier`](https://www.tensorflow.org/api_docs/python/tf/estimator/DNNClassifier) takes a "legacy" optimiser as its argument, so we need to replace `tf.keras.optimizers.*` with `tf.keras.optimizers.lecagy.*`.

---

### Additional suggestion on `tensorflow/tensorflow_estimator_simple.py`

According to TensorFlow docs, `tf.Estimators` are no longer recommended for v2 code, so we might be able to remove `tensorflow_estimator_simple.py` to reduce the maintenance cost since Optuna's CI doesn't run with tf v1.0.

> Warning: Estimators are not recommended for new code. Estimators run [v1.Session](https://www.tensorflow.org/api_docs/python/tf/compat/v1/Session)-style code which is more difficult to write correctly, and can behave unexpectedly, especially when combined with TF 2 code. Estimators do fall under our [compatibility guarantees](https://tensorflow.org/guide/versions), but will receive no fixes other than security vulnerabilities. See the [migration guide](https://tensorflow.org/guide/migrate) for details.
