### PR TITLE
Update pytorch-lightning version

### DIFF
--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -64,9 +64,10 @@ jobs:
         python pytorch/pytorch_lightning_simple.py
       env:
         OMP_NUM_THREADS: 1
-    - name: Run PyTorch Lightning DDP examples
-      run: |
-        python pytorch/pytorch_lightning_ddp.py
-        python pytorch/pytorch_lightning_ddp.py -p
-      env:
-        OMP_NUM_THREADS: 1
+    # TODO(Shinichi) Re-activate DDP test
+    # - name: Run PyTorch Lightning DDP examples
+      # run: |
+        # python pytorch/pytorch_lightning_ddp.py
+        # python pytorch/pytorch_lightning_ddp.py -p
+      # env:
+        # OMP_NUM_THREADS: 1

--- a/pytorch/pytorch_lightning_simple.py
+++ b/pytorch/pytorch_lightning_simple.py
@@ -29,8 +29,8 @@ from torchvision import datasets
 from torchvision import transforms
 
 
-if version.parse(pl.__version__) < version.parse("1.0.2"):
-    raise RuntimeError("PyTorch Lightning>=1.0.2 is required for this example.")
+if version.parse(pl.__version__) < version.parse("1.6.0"):
+    raise RuntimeError("PyTorch Lightning>=1.6.0 is required for this example.")
 
 PERCENT_VALID_EXAMPLES = 0.1
 BATCHSIZE = 128
@@ -40,7 +40,7 @@ DIR = os.getcwd()
 
 
 class Net(nn.Module):
-    def __init__(self, dropout: float, output_dims: List[int]):
+    def __init__(self, dropout: float, output_dims: List[int]) -> None:
         super().__init__()
         layers: List[nn.Module] = []
 
@@ -53,7 +53,7 @@ class Net(nn.Module):
 
         layers.append(nn.Linear(input_dim, CLASSES))
 
-        self.layers: nn.Module = nn.Sequential(*layers)
+        self.layers = nn.Sequential(*layers)
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         logits = self.layers(data)
@@ -61,19 +61,19 @@ class Net(nn.Module):
 
 
 class LightningNet(pl.LightningModule):
-    def __init__(self, dropout: float, output_dims: List[int]):
+    def __init__(self, dropout: float, output_dims: List[int]) -> None:
         super().__init__()
         self.model = Net(dropout, output_dims)
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         return self.model(data.view(-1, 28 * 28))
 
-    def training_step(self, batch, batch_idx: int) -> torch.Tensor:
+    def training_step(self, batch: torch.Tensor, batch_idx: int) -> torch.Tensor:
         data, target = batch
         output = self(data)
         return F.nll_loss(output, target)
 
-    def validation_step(self, batch, batch_idx: int) -> None:
+    def validation_step(self, batch: torch.Tensor, batch_idx: int) -> None:
         data, target = batch
         output = self(data)
         pred = output.argmax(dim=1, keepdim=True)
@@ -132,7 +132,8 @@ def objective(trial: optuna.trial.Trial) -> float:
         limit_val_batches=PERCENT_VALID_EXAMPLES,
         enable_checkpointing=False,
         max_epochs=EPOCHS,
-        gpus=1 if torch.cuda.is_available() else None,
+        accelerator="auto",
+        devices=1,
         callbacks=[PyTorchLightningPruningCallback(trial, monitor="val_acc")],
     )
     hyperparameters = dict(n_layers=n_layers, dropout=dropout, output_dims=output_dims)
@@ -153,9 +154,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    pruner: optuna.pruners.BasePruner = (
-        optuna.pruners.MedianPruner() if args.pruning else optuna.pruners.NopPruner()
-    )
+    pruner = optuna.pruners.MedianPruner() if args.pruning else optuna.pruners.NopPruner()
 
     study = optuna.create_study(direction="maximize", pruner=pruner)
     study.optimize(objective, n_trials=100, timeout=600)

--- a/pytorch/pytorch_lightning_simple.py
+++ b/pytorch/pytorch_lightning_simple.py
@@ -68,12 +68,12 @@ class LightningNet(pl.LightningModule):
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         return self.model(data.view(-1, 28 * 28))
 
-    def training_step(self, batch: torch.Tensor, batch_idx: int) -> torch.Tensor:
+    def training_step(self, batch: List[torch.Tensor], batch_idx: int) -> torch.Tensor:
         data, target = batch
         output = self(data)
         return F.nll_loss(output, target)
 
-    def validation_step(self, batch: torch.Tensor, batch_idx: int) -> None:
+    def validation_step(self, batch: List[torch.Tensor], batch_idx: int) -> None:
         data, target = batch
         output = self(data)
         pred = output.argmax(dim=1, keepdim=True)

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,8 +1,7 @@
 mpi4py
 plotly
 pytorch-ignite
-# todo(nzw0301): Remove the upper constraint https://github.com/optuna/optuna/issues/3418.
-pytorch-lightning>=1.5.0,<1.6.0
+pytorch-lightning>=1.6.0
 skorch
 torch==1.11.0
 torchvision==0.12.0


### PR DESCRIPTION
## Motivation
Update PyTorch Lightning version to >=1.6
## Description of the changes
PyTorch Lightning version for `optuna-example` is updated to >=1.6 as [PR #4322](https://github.com/optuna/optuna/pull/4322) is merged into the `master` of `optuna`. Note that DDP is temporally unsupported until [PR #4384](https://github.com/optuna/optuna/pull/4384) is merged into the `master`.
Type annotation is also updated based on the `setup.cfg` in `optuna`. 
