### PR TITLE
Install `optuna-integration` in `chainer` CI

### DIFF
--- a/.github/workflows/chainer.yml
+++ b/.github/workflows/chainer.yml
@@ -32,6 +32,8 @@ jobs:
         pip install --progress-bar off -U setuptools
         pip install git+https://github.com/optuna/optuna.git
         python -c 'import optuna'
+        pip install git+https://github.com/optuna/optuna-integration.git
+        python -c 'import optuna_integration'
 
         pip install -r chainer/requirements.txt
     - name: Run examples


### PR DESCRIPTION
## Motivation

Fix CI failure due to the `optuna-integration` migration.
The implementation of `optuna.integration.ChainerPruningExtension` was removed from `optuna.integration` and moved to the `optuna-integration` package in https://github.com/optuna/optuna/pull/4370.

`optuna-integration` is required to run the Chainer examples now.

## Description of the changes

- Install `optuna-integration` from the git repository
- `chainer/requirements.txt` should be updated as well, but we cannot because the `optuna-integration` package has not been released in PyPI yet.
