### PR TITLE
Add python 3.11 skimage's version matrix and remove warning for inputs data

### DIFF
--- a/.github/workflows/skimage.yml
+++ b/.github/workflows/skimage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/skimage/skimage_lbp_simple.py
+++ b/skimage/skimage_lbp_simple.py
@@ -19,7 +19,6 @@ from sklearn.metrics.pairwise import euclidean_distances
 
 
 def load_data():
-    rng = np.random.RandomState(0)
     dataset = load_digits()
     digits = dataset.images.astype(np.uint8)
     target = dataset.target

--- a/skimage/skimage_lbp_simple.py
+++ b/skimage/skimage_lbp_simple.py
@@ -1,8 +1,8 @@
 """
-Optuna example that optimizes a configuration for Olivetti faces dataset using
+Optuna example that optimizes a configuration for hand-written digits dataset using
 skimage.
 
-In this example, we optimize a classifier configuration for Olivetti faces dataset.
+In this example, we optimize a classifier configuration for hand-written digits dataset.
 We optimize parameters of local_binary_pattern function in skimage and the
 choice of distance metric classes.
 
@@ -12,7 +12,7 @@ import numpy as np
 import optuna
 
 import skimage.feature as ft
-from sklearn.datasets import fetch_olivetti_faces
+from sklearn.datasets import load_digits
 import sklearn.metrics
 from sklearn.metrics.pairwise import cosine_distances
 from sklearn.metrics.pairwise import euclidean_distances
@@ -20,18 +20,18 @@ from sklearn.metrics.pairwise import euclidean_distances
 
 def load_data():
     rng = np.random.RandomState(0)
-    dataset = fetch_olivetti_faces(shuffle=True, random_state=rng)
-    faces = dataset.images
+    dataset = load_digits()
+    digits = dataset.images.astype(np.uint8)
     target = dataset.target
     classes = np.unique(target)
     classes.sort()
 
     ref_index = np.argmax(target == classes[:, None], axis=1)
-    valid_index = np.delete(np.arange(len(faces)), ref_index)
+    valid_index = np.delete(np.arange(len(digits)), ref_index)
 
-    x_ref = faces[ref_index]
+    x_ref = digits[ref_index]
     y_ref = target[ref_index]
-    x_valid = faces[valid_index]
+    x_valid = digits[valid_index]
     y_valid = target[valid_index]
     return x_ref, x_valid, y_ref, y_valid
 
@@ -75,7 +75,7 @@ def calc_dist(p, q, metric):
 
 
 def objective(trial):
-    # Get Olivetti faces dataset.
+    # Get digits dataset.
     x_ref, x_valid, _, y_valid = load_data()
 
     # We optimize parameters of local_binary_pattern function in skimage


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

A part of https://github.com/optuna/optuna-examples/issues/164. Since scikit-image 0.2, `local_binary_pattern` shows a warning message if the images are float values because it internally converts images from int to float. 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Add python 3.11 to skimage's version matrix
- Replace face dataset with digit dataset.