### PR TITLE
Update pytorch lightning version for ddp

### DIFF
--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -69,10 +69,9 @@ jobs:
         python pytorch/pytorch_lightning_simple.py
       env:
         OMP_NUM_THREADS: 1
-    # TODO(Shinichi) Re-activate DDP test
-    # - name: Run PyTorch Lightning DDP examples
-      # run: |
-        # python pytorch/pytorch_lightning_ddp.py
-        # python pytorch/pytorch_lightning_ddp.py -p
-      # env:
-        # OMP_NUM_THREADS: 1
+    - name: Run PyTorch Lightning DDP examples
+      run: |
+        python pytorch/pytorch_lightning_ddp.py
+        python pytorch/pytorch_lightning_ddp.py -p
+      env:
+        OMP_NUM_THREADS: 1

--- a/pytorch/pytorch_lightning_ddp.py
+++ b/pytorch/pytorch_lightning_ddp.py
@@ -131,7 +131,7 @@ def objective(trial: optuna.trial.Trial) -> float:
         limit_val_batches=PERCENT_VALID_EXAMPLES,
         enable_checkpointing=False,
         max_epochs=EPOCHS,
-        accelerator="auto" if torch.cuda.is_available() else 'cpu',
+        accelerator="auto" if torch.cuda.is_available() else "cpu",
         devices="auto" if not torch.cuda.is_available() else os.cpu_count(),
         callbacks=[callback],
         strategy=DDPSpawnStrategy(find_unused_parameters=False),

--- a/pytorch/pytorch_lightning_ddp.py
+++ b/pytorch/pytorch_lightning_ddp.py
@@ -19,7 +19,6 @@ from typing import Optional
 import optuna
 from optuna.integration import PyTorchLightningPruningCallback
 import pytorch_lightning as pl
-from pytorch_lightning.strategies.ddp_spawn import DDPSpawnStrategy
 import torch
 from torch import nn
 from torch import optim
@@ -134,7 +133,7 @@ def objective(trial: optuna.trial.Trial) -> float:
         accelerator="auto" if torch.cuda.is_available() else "cpu",
         devices="auto" if not torch.cuda.is_available() else os.cpu_count(),
         callbacks=[callback],
-        strategy=DDPSpawnStrategy(find_unused_parameters=False),
+        strategy="ddp_spawn",
     )
     hyperparameters = dict(n_layers=n_layers, dropout=dropout, output_dims=output_dims)
     trainer.logger.log_hyperparams(hyperparameters)

--- a/pytorch/pytorch_lightning_ddp.py
+++ b/pytorch/pytorch_lightning_ddp.py
@@ -131,7 +131,7 @@ def objective(trial: optuna.trial.Trial) -> float:
         enable_checkpointing=False,
         max_epochs=EPOCHS,
         accelerator="auto" if torch.cuda.is_available() else "cpu",
-        devices="auto" if not torch.cuda.is_available() else os.cpu_count(),
+        devices=2,
         callbacks=[callback],
         strategy="ddp_spawn",
     )

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,8 +1,7 @@
 mpi4py
 plotly
 pytorch-ignite
-# TODO(Shinichi): Remove the version constraint on PyTorch Lightning
-pytorch-lightning>=1.6.0,<2.0.0
+pytorch-lightning>=1.6.0,
 skorch
 torch==1.11.0
 torchvision==0.12.0

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,6 +1,7 @@
 mpi4py
 plotly
 pytorch-ignite
+# TODO(Shinichi): Remove the version constraint on PyTorch Lightning
 pytorch-lightning>=1.6.0,<2.0.0
 skorch
 torch==1.11.0

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,7 +1,7 @@
 mpi4py
 plotly
 pytorch-ignite
-pytorch-lightning>=1.6.0
+pytorch-lightning>=1.6.0,<2.0.0
 skorch
 torch==1.11.0
 torchvision==0.12.0

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,7 +1,7 @@
 mpi4py
 plotly
 pytorch-ignite
-pytorch-lightning>=1.6.0,
+pytorch-lightning>=1.6.0
 skorch
 torch==1.11.0
 torchvision==0.12.0


### PR DESCRIPTION
## Motivation
Support DDP for PyTorch Lightning as it is supported in optuna/optuna.

## Description of the changes
This PR 
- replaces deprecated arguments with recommended ones
- adds manual evoking of `callback.check_pruned()` as changed in optuna/optuna#4384.

**Please merge this PR after optuna/optuna#4384 is merged into the `optuna/optuna:master`.**