### PR TITLE
Don't run evaluation twice on the last epoch

### DIFF
--- a/pytorch/pytorch_ignite_simple.py
+++ b/pytorch/pytorch_ignite_simple.py
@@ -104,7 +104,6 @@ def objective(trial):
 
     trainer.run(train_loader, max_epochs=EPOCHS)
 
-    evaluator.run(val_loader)
     return evaluator.state.metrics["accuracy"]
 
 


### PR DESCRIPTION
This fixes the bug which resulted in 'The reported value is ignored because this `step` X is already reported' warning