### PR TITLE
Install optnua integration on ci.

### DIFF
--- a/.github/workflows/allennlp.yml
+++ b/.github/workflows/allennlp.yml
@@ -28,6 +28,8 @@ jobs:
         pip install --progress-bar off -U setuptools
         pip install git+https://github.com/optuna/optuna.git
         python -c 'import optuna'
+        pip install git+https://github.com/optuna/optuna-integration.git
+        python -c 'import optuna_integration'
 
         pip install -r allennlp/requirements.txt
     - name: Run examples

--- a/.github/workflows/keras.yml
+++ b/.github/workflows/keras.yml
@@ -28,6 +28,8 @@ jobs:
         pip install --progress-bar off -U setuptools
         pip install git+https://github.com/optuna/optuna.git
         python -c 'import optuna'
+        pip install git+https://github.com/optuna/optuna-integration.git
+        python -c 'import optuna_integration'
 
         pip install -r keras/requirements.txt
     - name: Run examples


### PR DESCRIPTION
## Motivation
Follow up of https://github.com/optuna/optuna/issues/4484.

## Description of the changes
- Install `optuna-integration` on `keras` and `allennlp` ci workflow.
