### PR TITLE
Use BoTorch 0.8 or higher

### DIFF
--- a/multi_objective/botorch_simple.py
+++ b/multi_objective/botorch_simple.py
@@ -1,4 +1,3 @@
-from botorch.settings import suppress_botorch_warnings
 from botorch.settings import validate_input_scaling
 import optuna
 
@@ -29,7 +28,6 @@ def constraints(trial):
 
 if __name__ == "__main__":
     # Show warnings from BoTorch such as unnormalized input data warnings.
-    suppress_botorch_warnings(False)
     validate_input_scaling(True)
 
     sampler = optuna.integration.BoTorchSampler(

--- a/multi_objective/requirements.txt
+++ b/multi_objective/requirements.txt
@@ -1,4 +1,4 @@
-botorch>=0.4.0,<0.8.0
+botorch>=0.4.0
 fvcore
 torch
 torchaudio


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Optuna supports botorch 0.8.*, so the example also should works with it too.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Remove the upper version constraint of botorch
- Remove an old function `suppress_botorch_warnings`, which has been removed from BoTorch since BoTorch 0.8.3 see [the ref. commit](https://github.com/pytorch/botorch/commit/85bbf98a69531786b9a52a9e9b6eeeca8d791914)


Note that python 3.7 doesn't use BoTorch 0.8 and PyTorch 2.* since both have dropped python 3.7 support.