### PR TITLE
Use Gymnasium and pre-released Stable-Baselines3

### DIFF
--- a/.github/workflows/rl.yml
+++ b/.github/workflows/rl.yml
@@ -25,12 +25,12 @@ jobs:
     - name: Install (Python)
       run: |
         python -m pip install --upgrade pip
-        #TODO(nzw0301): Remove the following version constraint after resolving sb3 supports gymnasium https://github.com/DLR-RM/stable-baselines3/pull/780
-        pip install --progress-bar off -U setuptools==65.5.0
+        pip install --progress-bar off -U setuptools
         pip install git+https://github.com/optuna/optuna.git
         python -c 'import optuna'
 
-        pip install -r rl/requirements.txt
+        #TODO(not522): Remove pre option after stable-baselines3 v2.0.0 is released.
+        pip install --pre -r rl/requirements.txt
     - name: Run examples
       run: |
         python rl/sb3_simple.py

--- a/rl/sb3_simple.py
+++ b/rl/sb3_simple.py
@@ -1,6 +1,6 @@
 """ Optuna example that optimizes the hyperparameters of
 a reinforcement learning agent using A2C implementation from Stable-Baselines3
-on an OpenAI Gym environment.
+on a Gymnasium environment.
 
 This is a simplified version of what can be found in https://github.com/DLR-RM/rl-baselines3-zoo.
 
@@ -11,7 +11,7 @@ You can run this example as follows:
 from typing import Any
 from typing import Dict
 
-import gym
+import gymnasium
 import optuna
 from optuna.pruners import MedianPruner
 from optuna.samplers import TPESampler
@@ -80,7 +80,7 @@ class TrialEvalCallback(EvalCallback):
 
     def __init__(
         self,
-        eval_env: gym.Env,
+        eval_env: gymnasium.Env,
         trial: optuna.Trial,
         n_eval_episodes: int = 5,
         eval_freq: int = 10000,
@@ -117,7 +117,7 @@ def objective(trial: optuna.Trial) -> float:
     # Create the RL model.
     model = A2C(**kwargs)
     # Create env used for evaluation.
-    eval_env = Monitor(gym.make(ENV_ID))
+    eval_env = Monitor(gymnasium.make(ENV_ID))
     # Create the callback that will periodically evaluate and report the performance.
     eval_callback = TrialEvalCallback(
         eval_env, trial, n_eval_episodes=N_EVAL_EPISODES, eval_freq=EVAL_FREQ, deterministic=True


### PR DESCRIPTION
## Motivation
The rl CI has been failing while installing `gym`. Stable-Baselines3 will be updated to use Gymnasium instead of `gym`.
The detail is here: https://github.com/DLR-RM/stable-baselines3/pull/1327.

## Description of the changes
- Use Gymnasium and pre-released Stable-Baselines3