### PR TITLE
Fix the AllenNLP CI

### DIFF
--- a/allennlp/requirements.txt
+++ b/allennlp/requirements.txt
@@ -1,2 +1,5 @@
 allennlp>=2.2.0
+# This constraint is necessary to use the old Pydantic.
+# See https://github.com/pydantic/pydantic/issues/5821.
+typing_extensions<4.6.0
 optuna


### PR DESCRIPTION
## Motivation

With the release of typing-extension v4.6.0, Pydantic now produces an error.
It is fixed in the latest Pydantic (https://github.com/pydantic/pydantic/issues/5821), but we cannot use it because AllenNLP specifies the old spaCy and it specifies the old Pydantic.

## Description of the changes

- Add a version constraint.

This PR does not add a TODO comment because AllenNLP has been in maintenance mode and this issue is unlikely to be resolved.