### PR TITLE
Drop support for Python 3.7 on Haiku

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Resolve CI error (https://github.com/optuna/optuna-examples/actions/runs/5568342414).

## Description of the changes
`Haiku` have already drop support on Python 3.7 (https://github.com/deepmind/dm-haiku/commit/7034fe1204d24f6c6442b128a9b8dfe092fba6f5) and this PR follows their decision.
