### PR TITLE
Update Version Syntax for PyTorch and PyTorch Lightning Examples

### DIFF
--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,9 +1,9 @@
 mpi4py
 plotly
 pytorch-ignite
-pytorch-lightning>=1.6.0
+pytorch-lightning>=2.0
 skorch
-torch==1.11.0
-torchvision==0.12.0
-torchaudio==0.11.0
+torch>=2.0
+torchvision>=0.12.0
+torchaudio>=0.11.0
 optuna

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -3,7 +3,7 @@ plotly
 pytorch-ignite
 pytorch-lightning>=2.0
 skorch
-torch>=2.0
+torch>=1.11.0
 torchvision>=0.12.0
 torchaudio>=0.11.0
 optuna

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -1,9 +1,9 @@
 mpi4py
 plotly
 pytorch-ignite
-pytorch-lightning>=2.0
+pytorch-lightning
 skorch
-torch>=1.11.0
-torchvision>=0.12.0
-torchaudio>=0.11.0
+torch
+torchvision
+torchaudio
 optuna


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Fixes #204 

## Description of the changes
<!-- Describe the changes in this PR. -->

```diff
mpi4py
plotly
pytorch-ignite
-pytorch-lightning>=1.6.0
+pytorch-lightning>=2.0
skorch
-torch==1.11.0
+torch>=2.0
-torchvision==0.12.0
+torchvision>=0.12.0
-torchaudio==0.11.0
+torchaudio>=0.11.0
optuna
```

After installing PyTorch 2.0 and PyTorch Lightning 2.0, I ran `pytorch_simple` and `pytorch_lightning_simple` to confirm there were no issues with either example. Each ran without issue. 

Additionally, I bumped the minimum Python version to 3.8 in `pytorch.yml`.