### PR TITLE
Set version constraint on aim

### DIFF
--- a/aim/README.md
+++ b/aim/README.md
@@ -11,15 +11,15 @@ hyperparameters and metrics will be logged to `.aim` directory via integration c
 You can run this example as follows:
 
 ```sh
-$ python aim_integration.py
+python aim_integration.py
 ```
 
 After the script finishes, run the aim UI:
 
 ```sh
-$ aim up
+aim ui
 ```
 
-and view the optimization results at http://127.0.0.1:43800.
+and view the optimization results at <http://127.0.0.1:43800>.
 
 See also the [official example provided by aim](https://github.com/aimhubio/aim/blob/main/examples/optuna_track.py).

--- a/aim/aim_integration.py
+++ b/aim/aim_integration.py
@@ -17,6 +17,7 @@ and view the optimization results at http://127.0.0.1:43800.
 from aimstack.optuna_tracker.callbacks import BaseCallback as AimCallback
 import optuna
 
+from aim.optuna import AimCallback
 from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score

--- a/aim/aim_integration.py
+++ b/aim/aim_integration.py
@@ -16,7 +16,7 @@ and view the optimization results at http://127.0.0.1:43800.
 
 import optuna
 
-from aim.optuna import AimCallback
+from aimstack.optuna_tracker.callbacks import BaseCallback as AimCallback
 from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score

--- a/aim/aim_integration.py
+++ b/aim/aim_integration.py
@@ -14,7 +14,6 @@ Results and plots will be available in aim ui once script finishes:
 and view the optimization results at http://127.0.0.1:43800.
 """
 
-from aimstack.optuna_tracker.callbacks import BaseCallback as AimCallback
 import optuna
 
 from aim.optuna import AimCallback

--- a/aim/aim_integration.py
+++ b/aim/aim_integration.py
@@ -14,9 +14,9 @@ Results and plots will be available in aim ui once script finishes:
 and view the optimization results at http://127.0.0.1:43800.
 """
 
+from aimstack.optuna_tracker.callbacks import BaseCallback as AimCallback
 import optuna
 
-from aimstack.optuna_tracker.callbacks import BaseCallback as AimCallback
 from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score

--- a/aim/requirements.txt
+++ b/aim/requirements.txt
@@ -1,3 +1,3 @@
-aim
+aim<4
 optuna
 scikit-learn


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Fix CI error ([aim](https://github.com/optuna/optuna-examples/actions/runs/6353437227))

## Description of the changes
As written in [Quick start](https://aimstack.readthedocs.io/en/latest/getting_started/quick_start.html), aim requires to run  Aim Server for real time logging after v4, which will make CI complicated. This PR restricts its version smaller than 3 to avoid the trouble for now
~Update import path as `aim` split the integration module by https://github.com/aimhubio/aim/pull/2996~