### PR TITLE
Remove version specification of `jax` and `jaxlib`

### DIFF
--- a/haiku/requirements.txt
+++ b/haiku/requirements.txt
@@ -1,7 +1,6 @@
 dm-haiku
-# TODO(c-bata): Support jax v0.3.25 or newer
-jax==0.3.24
-jaxlib==0.3.24
+jax
+jaxlib
 numpy
 optax
 tensorflow

--- a/haiku/requirements.txt
+++ b/haiku/requirements.txt
@@ -3,5 +3,6 @@ jax
 jaxlib
 numpy
 optax
+optuna
 tensorflow
 tensorflow-datasets


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Remove version specification on haiku and resolve CI failure


## Description of the changes
This PR removes version specification of `jax` and `jaxlib` from `requirements.txt`
Note that the reason to pin the version, `jax_experimental_name_stack` option, has been resolved at `Haiku v0.0.9`
For more details see https://github.com/optuna/optuna-examples/pull/144 and https://github.com/google-deepmind/dm-haiku/releases/tag/v0.0.9.