### PR TITLE
Add `OptunaSearchCV` with terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The examples below provide codeblocks similar to the example above for various d
 * [Tensorflow (eager)](./tensorflow/tensorflow_eager_simple.py)
 * [XGBoost](./xgboost/xgboost_simple.py)
 
-
 ### An example of Optuna Dashboard
 
 The following example demonstrates how to use [Optuna Dashboard](https://github.com/optuna/optuna-dashboard).
@@ -69,6 +68,7 @@ The following example demonstrates how to use [Optuna Dashboard](https://github.
 ### An example where an objective function uses additional arguments
 
 The following example demonstrates how to implement an objective function that uses additional arguments other than `trial`.
+
 * [Scikit-learn (callable class version)](./sklearn/sklearn_additional_args.py)
 
 ### Examples of Pruning
@@ -107,6 +107,7 @@ In addition, integration modules are available for the following libraries, prov
 ### Examples of Terminator
 
 * [Optuna Terminator](./terminator/terminator_simple.py)
+* [OptunaSearchCV with Terminator](./terminator/terminator_search_cv.py)
 
 ### Examples of Multi-Objective Optimization
 
@@ -167,6 +168,7 @@ In addition, integration modules are available for the following libraries, prov
 PRs to add additional projects welcome!
 
 ### Running with Optuna's Docker images?
+
 You can use our docker images with the tag ending with `-dev` to run most of the examples.
 For example, you can run [PyTorch Simple](./pytorch/pytorch_simple.py) via `docker run --rm -v $(pwd):/prj -w /prj optuna/optuna:py3.7-dev python pytorch/pytorch_simple.py`.
 Also, you can try our visualization example in Jupyter Notebook by opening `localhost:8888` in your browser after executing this:

--- a/terminator/terminator_search_cv.py
+++ b/terminator/terminator_search_cv.py
@@ -1,0 +1,37 @@
+"""
+Optuna example that optimizes a classifier configuration using OptunaSearchCV.
+
+This example is the same as `sklearn/sklearn_optuna_search_cv_simple.py` except
+that you leave termination of the study up to the terminator callback.
+"""
+
+import optuna
+from optuna.terminator import TerminatorCallback
+
+from sklearn.datasets import load_iris
+from sklearn.svm import SVC
+
+
+if __name__ == "__main__":
+    clf = SVC(gamma="auto")
+
+    param_distributions = {
+        "C": optuna.distributions.FloatDistribution(1e-10, 1e10, log=True),
+        "degree": optuna.distributions.IntDistribution(1, 5),
+    }
+    terminator = TerminatorCallback()
+
+    optuna_search = optuna.integration.OptunaSearchCV(
+        clf, param_distributions, n_trials=100, timeout=600, verbose=2, callbacks=[terminator]
+    )
+
+    X, y = load_iris(return_X_y=True)
+    optuna_search.fit(X, y)
+
+    print("Best trial:")
+    trial = optuna_search.study_.best_trial
+
+    print("  Value: ", trial.value)
+    print("  Params: ")
+    for key, value in trial.params.items():
+        print("    {}: {}".format(key, value))


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Thanks to https://github.com/optuna/optuna/pull/5098, now we can use terminator in `OptunaSearchCV`.  This example shows how to use it.

## Description of the changes
The example itself is basically the same as `sklearn/sklearn_optuna_search_cv_simple.py` except that `TerminatorCallback` with default setting is passed to `OptunaSearchCV`.
I added the example under `terminator/` so that we don't have to change dependency of each module. 