### PR TITLE
Drop python 3.8 from haiku test

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Resolve CI failure.

## Description of the changes
Drop Python 3.8 test from CI, since it is not supported by the latest version `v0.0.11`.
See https://github.com/google-deepmind/dm-haiku/commit/a087e81a233b7f38f46c40801b76e7257eaca50e.