### PR TITLE
Remove Python 3.7 and 3.8 from tensorboard CI

### DIFF
--- a/.github/workflows/tensorboard.yml
+++ b/.github/workflows/tensorboard.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation
Python 3.8 is not supported in tensorboard 2.14.0 or later, and the tensorboard CI is failing.
This PR drops supports for Python 3.7 and 3.8.

## Description of the changes
Remove Python 3.7 and 3.8 from the tensorboard CI.