### PR TITLE
Specify black version in the CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,9 @@ jobs:
     - name: Install
       run: |
         python -m pip install -U pip
-        pip install --progress-bar off -U black hacking isort
+        pip install --progress-bar off -U hacking isort
+        # TODO(Shinichi): Remove version specification after black 24.x becomes stable.
+        pip install --progress-bar off -U "black<24.0.0"
 
     - name: black
       run: black . --check --diff


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The same as https://github.com/optuna/optuna/pull/5210.

## Description of the changes
Install `black<24.0.0` in the CI `Checks`. Although it is easy just to run black, it seems some bugs remain unresolved in the latest version as mentioned in https://github.com/optuna/optuna/issues/5208#issuecomment-1913827701. Therefore I specify the black version until it is stabilized as in `optuna/optuna` and `optuna/integaration`