### PR TITLE
Fix installation order

### DIFF
--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -26,12 +26,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --progress-bar off -U setuptools
+        pip install -r xgboost/requirements.txt
         pip install git+https://github.com/optuna/optuna.git
         python -c 'import optuna'
         pip install git+https://github.com/optuna/optuna-integration.git
         python -c 'import optuna_integration'
 
-        pip install -r xgboost/requirements.txt
     - name: Run XGBoost examples
       run: |
         python xgboost/xgboost_simple.py


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Fix current CI failure https://github.com/optuna/optuna-examples/actions/runs/7845757202

## Description of the changes
Although `optuna` and `optuna-integration` are installed from the master branch, they are overwritten right after the installation. This PR fixes the order.

https://github.com/optuna/optuna-examples/blob/01eaaed5b55250ca506fd0a53e179d2060917c0b/.github/workflows/xgboost.yml#L31-L34