### PR TITLE
Support tensorflow 2.16.1 and separate CI run for tensorflow estimator

### DIFF
--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
@@ -31,14 +31,18 @@ jobs:
         pip install git+https://github.com/optuna/optuna-integration.git
         python -c 'import optuna_integration'
 
-        # NOTE(nabenabe0928): Got "AttributeError: module 'tensorflow' has no attribute 'estimator'".
-        # TODO(nabenabe0928): Remove this version constraint.
-        pip install "tensorflow<2.16.1"
         pip install -r tensorflow/requirements.txt
-    - name: Run examples
+    - name: Run example of TensorFlow eager
       run: |
         python tensorflow/tensorflow_eager_simple.py
-        python tensorflow/tensorflow_estimator_simple.py
-        python tensorflow/tensorflow_estimator_integration.py
+      env:
+        OMP_NUM_THREADS: 1
+    - name: Run examples of TensorFlow estimator
+      run: |
+        if [ "${{ matrix.python-version }}" != "3.12" ] ; then
+          pip install "tensorflow<2.16.0"
+          python tensorflow/tensorflow_estimator_simple.py
+          python tensorflow/tensorflow_estimator_integration.py
+        fi
       env:
         OMP_NUM_THREADS: 1

--- a/tensorflow/tensorflow_estimator_integration.py
+++ b/tensorflow/tensorflow_estimator_integration.py
@@ -17,10 +17,14 @@ import urllib
 
 import optuna
 from optuna.trial import TrialState
+from packaging import version
 import tensorflow_datasets as tfds
 
 import tensorflow as tf
 
+
+if version.parse(tf.__version__) >= version.parse("2.16.0"):
+    raise RuntimeError("tensorflow<2.16.0 is required for this example.")
 
 # TODO(crcrpar): Remove the below three lines once everything is ok.
 # Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.

--- a/tensorflow/tensorflow_estimator_simple.py
+++ b/tensorflow/tensorflow_estimator_simple.py
@@ -13,10 +13,14 @@ import tempfile
 import urllib
 
 import optuna
+from packaging import version
 import tensorflow_datasets as tfds
 
 import tensorflow as tf
 
+
+if version.parse(tf.__version__) >= version.parse("2.16.0"):
+    raise RuntimeError("tensorflow<2.16.0 is required for this example.")
 
 # TODO(crcrpar): Remove the below three lines once everything is ok.
 # Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve TODO in  `.github/workflows/tensorflow.yml`: 

```
        # NOTE(nabenabe0928): Got "AttributeError: module 'tensorflow' has no attribute 'estimator'".
        # TODO(nabenabe0928): Remove this version constraint.
        pip install "tensorflow<2.16.1"
```

The root error is that tensorflow 2.16.1 has broken backward compatibility for tensorflow estimator that is not available anymore. In my understanding, the alternative is keras, so we cannot use estimator examples with tensorflow 2.16.1 or higher.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Revert the hotfix for TF introduced by https://github.com/optuna/optuna-examples/pull/245
- Add `RuntimeError` based on the tensorflow version for estimator example and add a new run in github CI for estimator scripts.
- Add python 3.12 because tensorflow 2.16.1 starts to support it. 

---

More background: TensorFlow estimator has been removed since TensorFlow 2.16.1 according to https://www.tensorflow.org/guide/estimator and https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1.