### PR TITLE
Drop Python 3.7 support for wandb

### DIFF
--- a/.github/workflows/wandb.yml
+++ b/.github/workflows/wandb.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation
wandb currently does not work with Python 3.7, and Python 3.7 has reached EOL.

## Description of the changes
Drop Python 3.7 support for wandb.