### PR TITLE
Install `tensorflow-cpu` in CIs

### DIFF
--- a/haiku/requirements.txt
+++ b/haiku/requirements.txt
@@ -4,5 +4,5 @@ jaxlib
 numpy
 optax
 optuna
-tensorflow
+tensorflow-cpu
 tensorflow-datasets

--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,4 +1,4 @@
 keras
 optuna
-tensorflow
+tensorflow-cpu
 tensorflow-datasets

--- a/mlflow/requirements.txt
+++ b/mlflow/requirements.txt
@@ -1,4 +1,4 @@
 mlflow
 optuna
 scikit-learn
-tensorflow
+tensorflow-cpu

--- a/tensorboard/requirements.txt
+++ b/tensorboard/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow
+tensorflow-cpu

--- a/tensorflow/requirements.txt
+++ b/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow-estimator
-tensorflow>=2.11.0
+tensorflow-cpu>=2.11.0
 tensorflow-datasets
 optuna

--- a/tfkeras/requirements.txt
+++ b/tfkeras/requirements.txt
@@ -1,3 +1,3 @@
 optuna
-tensorflow
+tensorflow-cpu
 tensorflow-datasets


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
In the CPU-only environment, `tensorflow-cpu` is recommended. https://www.tensorflow.org/install/pip
It has a smaller package size and may reduce errors during download in the CIs.
For example, the size of `
tensorflow-2.16.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ` is 589.8 MB, but `tensorflow_cpu-2.16.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` is 214.1 MB.

## Description of the changes
<!-- Describe the changes in this PR. -->
Install `tensorflow-cpu` instead of `tensorflow`.