### PR TITLE
Fix CI with version constraints of packages

### DIFF
--- a/.github/workflows/chainer.yml
+++ b/.github/workflows/chainer.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/multi_objective.yml
+++ b/.github/workflows/multi_objective.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/allennlp/requirements.txt
+++ b/allennlp/requirements.txt
@@ -1,4 +1,5 @@
 allennlp>=2.2.0
+numpy<2.0.0
 # This constraint is necessary to use the old Pydantic.
 # See https://github.com/pydantic/pydantic/issues/5821.
 typing_extensions<4.6.0

--- a/allennlp/requirements.txt
+++ b/allennlp/requirements.txt
@@ -1,5 +1,5 @@
 allennlp>=2.2.0
-numpy<2.0.0
+numpy<2.0.0  # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
 # This constraint is necessary to use the old Pydantic.
 # See https://github.com/pydantic/pydantic/issues/5821.
 typing_extensions<4.6.0

--- a/chainer/requirements.txt
+++ b/chainer/requirements.txt
@@ -1,3 +1,4 @@
 chainer
 mpi4py
+numpy==1.26.4
 optuna

--- a/chainer/requirements.txt
+++ b/chainer/requirements.txt
@@ -1,4 +1,4 @@
 chainer
 mpi4py
-numpy==1.26.4
+numpy<2.0.0 # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
 optuna

--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,5 +1,5 @@
 keras
-numpy<2.0.0
+numpy<2.0.0  # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
 optuna
 tensorflow-cpu
 tensorflow-datasets

--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,4 +1,5 @@
 keras
+numpy<2.0.0
 optuna
 tensorflow-cpu
 tensorflow-datasets

--- a/multi_objective/requirements.txt
+++ b/multi_objective/requirements.txt
@@ -1,4 +1,4 @@
-botorch>=0.4.0
+botorch>=0.8.0
 fvcore
 torch
 torchaudio


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
- Fix CI error caused by numpy 2.0.0.
- Update botorch version to >= 8.0.0 (because https://github.com/optuna/optuna-integration/pull/125 requires `ListSampler`)
## Description of the changes
- Add version constraint to numpy and botorch for CIs broken
- Disable CI with Python 3.7 for multi_objective because botorch 0.8.0 requires Python >= 3.8