### PR TITLE
Use auc score to unify the intermediate and objective values

### DIFF
--- a/lightgbm/lightgbm_integration.py
+++ b/lightgbm/lightgbm_integration.py
@@ -14,6 +14,7 @@ import optuna
 
 import lightgbm as lgb
 import sklearn.datasets
+import sklearn.metrics
 from sklearn.model_selection import train_test_split
 
 
@@ -43,7 +44,8 @@ def objective(trial):
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
     gbm = lgb.train(param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback])
 
-    return gbm.best_score["valid_0"]["auc"]
+    preds = gbm.predict(valid_x)
+    return sklearn.metrics.roc_auc_score(valid_y, preds)
 
 
 if __name__ == "__main__":

--- a/lightgbm/lightgbm_integration.py
+++ b/lightgbm/lightgbm_integration.py
@@ -10,12 +10,10 @@ You can run this example as follows:
 
 """
 
-import numpy as np
 import optuna
 
 import lightgbm as lgb
 import sklearn.datasets
-import sklearn.metrics
 from sklearn.model_selection import train_test_split
 
 
@@ -45,10 +43,7 @@ def objective(trial):
     pruning_callback = optuna.integration.LightGBMPruningCallback(trial, "auc")
     gbm = lgb.train(param, dtrain, valid_sets=[dvalid], callbacks=[pruning_callback])
 
-    preds = gbm.predict(valid_x)
-    pred_labels = np.rint(preds)
-    accuracy = sklearn.metrics.accuracy_score(valid_y, pred_labels)
-    return accuracy
+    return gbm.best_score["valid_0"]["auc"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve https://github.com/optuna/optuna-examples/issues/251.

## Description of the changes
<!-- Describe the changes in this PR. -->

Use pre-computed booster's validation auc score rather than computing inconsistent accuracy.

Alternative ways I considered were not working by the following reasons:
- Compute AUC score using sklearn: We cannot calculate the AUC score because `gbm` does not have `predict_prob` method https://github.com/dmlc/xgboost/issues/4583, which is necessary to compute the score
- Use accuracy as the intermediate values: I suppose the accuracy metric isn't provided by [metrics](https://lightgbm.readthedocs.io/en/latest/Parameters.html#metric-parameters) in lightgbm. 