### PR TITLE
Add python 3.12 for mlflow CI python versions

### DIFF
--- a/.github/workflows/mlflow.yml
+++ b/.github/workflows/mlflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve a subtaks of https://github.com/optuna/optuna-examples/issues/230.

## Description of the changes
<!-- Describe the changes in this PR. -->

I confirmed that the example works with python 3.12 locally, so we might be able to add python 3.12. 