### PR TITLE
Add python 3.12 to CI python versions for `keras` and `tensorboard` examples

### DIFF
--- a/.github/workflows/keras.yml
+++ b/.github/workflows/keras.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tensorboard.yml
+++ b/.github/workflows/tensorboard.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

https://github.com/optuna/optuna-examples/issues/230

## Description of the changes
<!-- Describe the changes in this PR. -->

Add python 3.12 because I could run the examples with python 3.12 locally without any error or warning messages.