### PR TITLE
Update CI config for fastai

### DIFF
--- a/.github/workflows/fastai.yml
+++ b/.github/workflows/fastai.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation & Description of the changes

The latest fastai requires numpy >= 2.0 that does not work on Python < 3.9.
This PR disables the fastai CI for Python < 3.9.
