### PR TITLE
Fix syntax error in YAML file of rapids CI

### DIFF
--- a/.github/workflows/rapids.yml
+++ b/.github/workflows/rapids.yml
@@ -28,9 +28,8 @@ jobs:
           pip install --progress-bar off -U setuptools
           pip install git+https://github.com/optuna/optuna.git
           python -c 'import optuna'
-
-    - name: Run examples
-      run: |
-        python -m py_compile rapids/rapids_simple.py  # due to difficulty in importing, compile only
-      env:
-        OMP_NUM_THREADS: 1
+      - name: Run examples
+        run: |
+          python -m py_compile rapids/rapids_simple.py  # due to difficulty in importing, compile only
+        env:
+          OMP_NUM_THREADS: 1


### PR DESCRIPTION
## Motivation

This PR will resolve the syntax error in rapids.yaml.
As we can see the following [CI result](https://github.com/optuna/optuna-examples/actions/runs/11285478836), the `Run examples` block is not correctly indented:

```
GitHub Actions .github/workflows/rapids.yml
Invalid workflow file
You have an error in your yaml syntax on line 12
```


## Description of the changes

- Fix the indent of the lines in rapids.yaml
