### PR TITLE
Add python 3.12 to lightgbm CI

### DIFF
--- a/.github/workflows/lightgbm.yml
+++ b/.github/workflows/lightgbm.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Close https://github.com/optuna/optuna-examples/issues/230

## Description of the changes
<!-- Describe the changes in this PR. -->

Just add Python 3.12 to its CI config. When I investigated this issue before: https://github.com/optuna/optuna-examples/issues/230#issuecomment-2266440949, there were a few issues, but I realised that it might be caused by my local environment.