### PR TITLE
Adapt docker recipes to Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ Our Docker images for most examples are available with the tag ending with `-dev
 For example, [PyTorch Simple](./pytorch/pytorch_simple.py) can be run via:
 
 ```bash
-$ docker run --rm -v $(pwd):/prj -w /prj optuna/optuna:py3.7-dev python pytorch/pytorch_simple.py
+$ docker run --rm -v $(pwd):/prj -w /prj optuna/optuna:py3.11-dev python pytorch/pytorch_simple.py
 ```
 
 Additionally, our visualization example can also be run on Jupyter Notebook by opening `localhost:8888` in your browser after executing the following:
 
 ```bash
-$ docker run -p 8888:8888 --rm optuna/optuna:py3.7-dev jupyter notebook --allow-root --no-browser --port 8888 --ip 0.0.0.0 --NotebookApp.token='' --NotebookApp.password=''
+$ docker run -p 8888:8888 --rm optuna/optuna:py3.11-dev jupyter notebook --allow-root --no-browser --port 8888 --ip 0.0.0.0 --NotebookApp.token='' --NotebookApp.password=''
 ```

--- a/kubernetes/mlflow/Dockerfile
+++ b/kubernetes/mlflow/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(crcrpar): optuna/optuna:py3.7-dev can be used as base instead.
-FROM python:3.11-slim-buster
+FROM python:3.11-slim
 
 WORKDIR /usr/src/
 

--- a/kubernetes/mlflow/Dockerfile
+++ b/kubernetes/mlflow/Dockerfile
@@ -1,13 +1,11 @@
 # NOTE(crcrpar): optuna/optuna:py3.7-dev can be used as base instead.
-FROM python:3.7-slim-buster
+FROM python:3.11-slim-buster
 
 WORKDIR /usr/src/
 
 RUN pip install --no-cache-dir optuna psycopg2-binary mlflow \
-    && pip install --no-cache-dir \
-        torch==1.10.0+cpu \
-        torchvision==0.11.1+cpu \
-        -f https://download.pytorch.org/whl/torch_stable.html \
+    && pip install --no-cache-dir torch torchvision \
+        --index-url https://download.pytorch.org/whl/cpu \
     && pip install pytorch-lightning
 
 COPY pytorch_lightning_distributed.py .

--- a/kubernetes/simple/Dockerfile
+++ b/kubernetes/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim
 
 WORKDIR /usr/src/
 

--- a/kubernetes/simple/Dockerfile
+++ b/kubernetes/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.11-slim-buster
 
 WORKDIR /usr/src/
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As we dropped Python 3.7, I updated the docker image recipes to Python 3.11.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Replace Python 3.7 with Python 3.11
- Update torch install command