### PR TITLE
Limit the version of wandb < 0.19.0 to fix the CI error

### DIFF
--- a/wandb/requirements.txt
+++ b/wandb/requirements.txt
@@ -1,3 +1,3 @@
 optuna
 scikit-learn
-wandb
+wandb<0.19.0


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To fix the CI error: https://github.com/optuna/optuna-examples/actions/runs/12182457910. This is caused by the recent wandb 0.19.0 release. I will limit the version. 

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add the version constraint on wandb
