### PR TITLE
[hotfix] Add the version constraint on lightgbm

### DIFF
--- a/.github/workflows/lightgbm.yml
+++ b/.github/workflows/lightgbm.yml
@@ -32,6 +32,9 @@ jobs:
         python -c 'import optuna_integration'
 
         pip install -r lightgbm/requirements.txt
+
+        # TODO(c-bata): Remove the version constraint on LightGBM once the issue is fixed.
+        pip install "lightgbm<=4.5.0"
     - name: Run LightGBM examples
       run: |
         python lightgbm/lightgbm_simple.py


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
To resolve https://github.com/optuna/optuna-integration/actions/runs/13359662201

## Description of the changes
<!-- Describe the changes in this PR. -->
LightGBM 4.6.0 was released two days ago, causing the workflow to fail. This PR adds a version constraint on LightGBM as a hotfix.