### PR TITLE
Fix fastai Example

### DIFF
--- a/.github/workflows/fastai.yml
+++ b/.github/workflows/fastai.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # TODO(c-bata): Add Python 3.9 here after fixing https://github.com/optuna/optuna-examples/issues/307
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.9','3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/fastai/fastai_simple.py
+++ b/fastai/fastai_simple.py
@@ -11,7 +11,7 @@ as this uses the entire MNIST dataset.
 
 You can run this example as follows, pruning can be turned on and off with the `--pruning`
 argument.
-    $ python fastaiv2_simple.py [--pruning]
+    $ python fastai_simple.py [--pruning]
 """
 
 import argparse


### PR DESCRIPTION
Fixes #307 

The release of fastai 2.8.0 has been yanked on PyPI which can be viewed [here](https://pypi.org/project/fastai/2.8.0/#history).  I tested out the example in a venv with python 3.9.21 and fastai 2.7.19 and it gave the following output:

Number of finished trials: 13
Best trial:
  Value: 0.9980372786521912
  Params: 
    apply_tfms: True
    max_rotate: 45
    max_zoom: 1.857517179212782
    p_affine: 0.2
    n_layers: 5
    n_channels_0: 22
    n_channels_1: 24
    n_channels_2: 22
    n_channels_3: 15
    n_channels_4: 31

All the tests are also passing. Could you please review?

cc: @c-bata 
