### PR TITLE
Update PyTorch Checkpoint Example using tempfile

### DIFF
--- a/pytorch/pytorch_checkpoint.py
+++ b/pytorch/pytorch_checkpoint.py
@@ -14,6 +14,7 @@ previous saved checkpoint using heartbeat.
 """
 
 import os
+import tempfile
 
 import optuna
 from optuna.artifacts import download_artifact
@@ -37,35 +38,32 @@ EPOCHS = 10
 LOG_INTERVAL = 10
 N_TRAIN_EXAMPLES = BATCHSIZE * 30
 N_VALID_EXAMPLES = BATCHSIZE * 10
-CHECKPOINT_DIR = "pytorch_checkpoint"
 
+# Setup artifact directory
 base_path = "./artifacts"
 os.makedirs(base_path, exist_ok=True)
 artifact_store = FileSystemArtifactStore(base_path=base_path)
 
 
 def define_model(trial):
-    # We optimize the number of layers, hidden units and dropout ratio in each layer.
     n_layers = trial.suggest_int("n_layers", 1, 3)
     layers = []
-
     in_features = 28 * 28
+
     for i in range(n_layers):
-        out_features = trial.suggest_int("n_units_l{}".format(i), 4, 128)
+        out_features = trial.suggest_int(f"n_units_l{i}", 4, 128)
         layers.append(nn.Linear(in_features, out_features))
         layers.append(nn.ReLU())
-        p = trial.suggest_float("dropout_l{}".format(i), 0.2, 0.5)
+        p = trial.suggest_float(f"dropout_l{i}", 0.2, 0.5)
         layers.append(nn.Dropout(p))
-
         in_features = out_features
+
     layers.append(nn.Linear(in_features, CLASSES))
     layers.append(nn.LogSoftmax(dim=1))
-
     return nn.Sequential(*layers)
 
 
 def get_mnist():
-    # Load FashionMNIST dataset.
     train_loader = torch.utils.data.DataLoader(
         datasets.FashionMNIST(DIR, train=True, download=True, transform=transforms.ToTensor()),
         batch_size=BATCHSIZE,
@@ -76,21 +74,19 @@ def get_mnist():
         batch_size=BATCHSIZE,
         shuffle=True,
     )
-
     return train_loader, valid_loader
 
 
 def objective(trial):
-    # Generate the model.
     model = define_model(trial).to(DEVICE)
 
-    # Generate the optimizers.
     optimizer_name = trial.suggest_categorical("optimizer", ["Adam", "RMSprop", "SGD"])
     lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
     optimizer = getattr(optim, optimizer_name)(model.parameters(), lr=lr)
 
     artifact_id = None
     retry_history = RetryFailedTrialCallback.retry_history(trial)
+
     for trial_number in reversed(retry_history):
         artifact_id = trial.study.trials[trial_number].user_attrs.get("artifact_id")
         if artifact_id is not None:
@@ -98,65 +94,57 @@ def objective(trial):
             break
 
     if artifact_id is not None:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as tmp_file:
+            temp_path = tmp_file.name
+
         download_artifact(
-            artifact_store=artifact_store,
-            file_path=f"./tmp_model_{trial.number}.pt",
-            artifact_id=artifact_id,
+            artifact_store=artifact_store, file_path=temp_path, artifact_id=artifact_id
         )
-        checkpoint = torch.load(f"./tmp_model_{trial.number}.pt")
-        os.remove(f"./tmp_model_{trial.number}.pt")
-        epoch = checkpoint["epoch"]
-        epoch_begin = epoch + 1
+        checkpoint = torch.load(temp_path)
+        os.remove(temp_path)
 
-        print(f"Loading a checkpoint from trial {retry_trial_number} in epoch {epoch}.")
-
+        epoch_begin = checkpoint["epoch"] + 1
+        print(
+            f"Loading a checkpoint from trial {retry_trial_number} in epoch {checkpoint['epoch']}."
+        )
         model.load_state_dict(checkpoint["model_state_dict"])
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         accuracy = checkpoint["accuracy"]
     else:
         epoch_begin = 0
 
-    # Get the FashionMNIST dataset.
     train_loader, valid_loader = get_mnist()
 
-    # Training of the model.
     for epoch in range(epoch_begin, EPOCHS):
         model.train()
         for batch_idx, (data, target) in enumerate(train_loader):
-            # Limiting training data for faster epochs.
             if batch_idx * BATCHSIZE >= N_TRAIN_EXAMPLES:
                 break
-
             data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
-
             optimizer.zero_grad()
             output = model(data)
             loss = F.nll_loss(output, target)
             loss.backward()
             optimizer.step()
 
-        # Validation of the model.
         model.eval()
         correct = 0
         with torch.no_grad():
             for batch_idx, (data, target) in enumerate(valid_loader):
-                # Limiting validation data.
                 if batch_idx * BATCHSIZE >= N_VALID_EXAMPLES:
                     break
                 data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
                 output = model(data)
-                # Get the index of the max log-probability.
                 pred = output.argmax(dim=1, keepdim=True)
                 correct += pred.eq(target.view_as(pred)).sum().item()
 
         accuracy = correct / min(len(valid_loader.dataset), N_VALID_EXAMPLES)
-
         trial.report(accuracy, epoch)
 
-        # Save optimization status. We should save the objective value because the process may be
-        # killed between saving the last model and recording the objective value to the storage.
-
         print(f"Saving a checkpoint in epoch {epoch}.")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as tmp_file:
+            temp_path = tmp_file.name
 
         torch.save(
             {
@@ -165,17 +153,14 @@ def objective(trial):
                 "optimizer_state_dict": optimizer.state_dict(),
                 "accuracy": accuracy,
             },
-            f"./tmp_model_{trial.number}.pt",
+            temp_path,
         )
         artifact_id = upload_artifact(
-            artifact_store=artifact_store,
-            file_path=f"./tmp_model_{trial.number}.pt",
-            study_or_trial=trial,
+            artifact_store=artifact_store, file_path=temp_path, study_or_trial=trial
         )
         trial.set_user_attr("artifact_id", artifact_id)
-        os.remove(f"./tmp_model_{trial.number}.pt")
+        os.remove(temp_path)
 
-        # Handle pruning based on the intermediate value.
         if trial.should_prune():
             raise optuna.exceptions.TrialPruned()
 
@@ -189,26 +174,26 @@ if __name__ == "__main__":
         failed_trial_callback=RetryFailedTrialCallback(),
     )
     study = optuna.create_study(
-        storage=storage, study_name="pytorch_checkpoint", direction="maximize", load_if_exists=True
+        storage=storage,
+        study_name="pytorch_checkpoint",
+        direction="maximize",
+        load_if_exists=True,
     )
     study.optimize(objective, n_trials=10, timeout=600)
 
     pruned_trials = study.get_trials(states=(optuna.trial.TrialState.PRUNED,))
     complete_trials = study.get_trials(states=(optuna.trial.TrialState.COMPLETE,))
 
-    print("Study statistics: ")
+    print("Study statistics:")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))
     print("  Number of complete trials: ", len(complete_trials))
 
     print("Best trial:")
     trial = study.best_trial
-
     print("  Value: ", trial.value)
-
     print("  Params: ")
     for key, value in trial.params.items():
-        print("    {}: {}".format(key, value))
+        print(f"    {key}: {value}")
 
-    # The line of the resumed trial's intermediate values begins with the restarted epoch.
     optuna.visualization.plot_intermediate_values(study).show()

--- a/pytorch/pytorch_checkpoint.py
+++ b/pytorch/pytorch_checkpoint.py
@@ -106,7 +106,7 @@ def objective(trial):
             epoch_begin = checkpoint["epoch"] + 1
 
             print(
-                f"Loading a checkpoint from trial {retry_trial_number} in epoch {checkpoint['epoch']}."
+                f"Loading checkpoint from trial {retry_trial_number}, epoch {checkpoint['epoch']}."
             )
 
             model.load_state_dict(checkpoint["model_state_dict"])

--- a/pytorch/pytorch_checkpoint.py
+++ b/pytorch/pytorch_checkpoint.py
@@ -38,19 +38,18 @@ EPOCHS = 10
 LOG_INTERVAL = 10
 N_TRAIN_EXAMPLES = BATCHSIZE * 30
 N_VALID_EXAMPLES = BATCHSIZE * 10
+CHECKPOINT_DIR = "pytorch_checkpoint"
 
-# Setup artifact directory
 base_path = "./artifacts"
 os.makedirs(base_path, exist_ok=True)
 artifact_store = FileSystemArtifactStore(base_path=base_path)
 
 
 def define_model(trial):
-    # We optimize the number of layers, hidden units and dropout ratio in each layer.
     n_layers = trial.suggest_int("n_layers", 1, 3)
     layers = []
-    in_features = 28 * 28
 
+    in_features = 28 * 28
     for i in range(n_layers):
         out_features = trial.suggest_int(f"n_units_l{i}", 4, 128)
         layers.append(nn.Linear(in_features, out_features))
@@ -61,11 +60,11 @@ def define_model(trial):
 
     layers.append(nn.Linear(in_features, CLASSES))
     layers.append(nn.LogSoftmax(dim=1))
+
     return nn.Sequential(*layers)
 
 
 def get_mnist():
-    # Load FashionMNIST dataset.
     train_loader = torch.utils.data.DataLoader(
         datasets.FashionMNIST(DIR, train=True, download=True, transform=transforms.ToTensor()),
         batch_size=BATCHSIZE,
@@ -80,102 +79,91 @@ def get_mnist():
 
 
 def objective(trial):
-    # Generate the model.
     model = define_model(trial).to(DEVICE)
 
-    # Generate the optimizers.
     optimizer_name = trial.suggest_categorical("optimizer", ["Adam", "RMSprop", "SGD"])
     lr = trial.suggest_float("lr", 1e-5, 1e-1, log=True)
     optimizer = getattr(optim, optimizer_name)(model.parameters(), lr=lr)
 
     artifact_id = None
     retry_history = RetryFailedTrialCallback.retry_history(trial)
-
     for trial_number in reversed(retry_history):
         artifact_id = trial.study.trials[trial_number].user_attrs.get("artifact_id")
         if artifact_id is not None:
             retry_trial_number = trial_number
             break
 
-    if artifact_id is not None:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as tmp_file:
-            temp_path = tmp_file.name
+    with tempfile.TemporaryDirectory() as tmpdir:
+        checkpoint_path = os.path.join(tmpdir, "checkpoint.pt")
 
-        download_artifact(
-            artifact_store=artifact_store, file_path=temp_path, artifact_id=artifact_id
-        )
-        checkpoint = torch.load(temp_path)
-        os.remove(temp_path)
+        if artifact_id is not None:
+            download_artifact(
+                artifact_store=artifact_store,
+                file_path=checkpoint_path,
+                artifact_id=artifact_id,
+            )
+            checkpoint = torch.load(checkpoint_path)
+            epoch_begin = checkpoint["epoch"] + 1
 
-        epoch_begin = checkpoint["epoch"] + 1
-        print(
-            f"Loading a checkpoint from trial {retry_trial_number} in epoch {checkpoint['epoch']}."
-        )
-        model.load_state_dict(checkpoint["model_state_dict"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        accuracy = checkpoint["accuracy"]
-    else:
-        epoch_begin = 0
+            print(
+                f"Loading a checkpoint from trial {retry_trial_number} in epoch {checkpoint['epoch']}."
+            )
 
-    # Get the FashionMNIST dataset.
-    train_loader, valid_loader = get_mnist()
+            model.load_state_dict(checkpoint["model_state_dict"])
+            optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+            accuracy = checkpoint["accuracy"]
+        else:
+            epoch_begin = 0
 
-    # Training of the model.
-    for epoch in range(epoch_begin, EPOCHS):
-        model.train()
-        for batch_idx, (data, target) in enumerate(train_loader):
-            # Limiting training data for faster epochs.
-            if batch_idx * BATCHSIZE >= N_TRAIN_EXAMPLES:
-                break
-            data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
-            optimizer.zero_grad()
-            output = model(data)
-            loss = F.nll_loss(output, target)
-            loss.backward()
-            optimizer.step()
+        train_loader, valid_loader = get_mnist()
 
-        # Validation of the model.
-        model.eval()
-        correct = 0
-        with torch.no_grad():
-            for batch_idx, (data, target) in enumerate(valid_loader):
-                # Limiting validation data.
-                if batch_idx * BATCHSIZE >= N_VALID_EXAMPLES:
+        for epoch in range(epoch_begin, EPOCHS):
+            model.train()
+            for batch_idx, (data, target) in enumerate(train_loader):
+                if batch_idx * BATCHSIZE >= N_TRAIN_EXAMPLES:
                     break
                 data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
-                # Get the index of the max log-probability.
+                optimizer.zero_grad()
                 output = model(data)
-                pred = output.argmax(dim=1, keepdim=True)
-                correct += pred.eq(target.view_as(pred)).sum().item()
+                loss = F.nll_loss(output, target)
+                loss.backward()
+                optimizer.step()
 
-        accuracy = correct / min(len(valid_loader.dataset), N_VALID_EXAMPLES)
-        trial.report(accuracy, epoch)
+            model.eval()
+            correct = 0
+            with torch.no_grad():
+                for batch_idx, (data, target) in enumerate(valid_loader):
+                    if batch_idx * BATCHSIZE >= N_VALID_EXAMPLES:
+                        break
+                    data, target = data.view(data.size(0), -1).to(DEVICE), target.to(DEVICE)
+                    output = model(data)
+                    pred = output.argmax(dim=1, keepdim=True)
+                    correct += pred.eq(target.view_as(pred)).sum().item()
 
-        # Save optimization status. We should save the objective value because the process may be
-        # killed between saving the last model and recording the objective value to the storage.
-        print(f"Saving a checkpoint in epoch {epoch}.")
+            accuracy = correct / min(len(valid_loader.dataset), N_VALID_EXAMPLES)
+            trial.report(accuracy, epoch)
 
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as tmp_file:
-            temp_path = tmp_file.name
+            print(f"Saving a checkpoint in epoch {epoch}.")
 
-        torch.save(
-            {
-                "epoch": epoch,
-                "model_state_dict": model.state_dict(),
-                "optimizer_state_dict": optimizer.state_dict(),
-                "accuracy": accuracy,
-            },
-            temp_path,
-        )
-        artifact_id = upload_artifact(
-            artifact_store=artifact_store, file_path=temp_path, study_or_trial=trial
-        )
-        trial.set_user_attr("artifact_id", artifact_id)
-        os.remove(temp_path)
+            torch.save(
+                {
+                    "epoch": epoch,
+                    "model_state_dict": model.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "accuracy": accuracy,
+                },
+                checkpoint_path,
+            )
 
-        # Handle pruning based on the intermediate value.
-        if trial.should_prune():
-            raise optuna.exceptions.TrialPruned()
+            artifact_id = upload_artifact(
+                artifact_store=artifact_store,
+                file_path=checkpoint_path,
+                study_or_trial=trial,
+            )
+            trial.set_user_attr("artifact_id", artifact_id)
+
+            if trial.should_prune():
+                raise optuna.exceptions.TrialPruned()
 
     return accuracy
 
@@ -197,7 +185,7 @@ if __name__ == "__main__":
     pruned_trials = study.get_trials(states=(optuna.trial.TrialState.PRUNED,))
     complete_trials = study.get_trials(states=(optuna.trial.TrialState.COMPLETE,))
 
-    print("Study statistics:")
+    print("Study statistics: ")
     print("  Number of finished trials: ", len(study.trials))
     print("  Number of pruned trials: ", len(pruned_trials))
     print("  Number of complete trials: ", len(complete_trials))
@@ -205,9 +193,9 @@ if __name__ == "__main__":
     print("Best trial:")
     trial = study.best_trial
     print("  Value: ", trial.value)
+
     print("  Params: ")
     for key, value in trial.params.items():
         print(f"    {key}: {value}")
 
-    # The line of the resumed trial's intermediate values begins with the restarted epoch.
     optuna.visualization.plot_intermediate_values(study).show()


### PR DESCRIPTION
Fixes #299 

I've updated the example to use the tempfile module instead of using temporary files. The following output is seen:

Study statistics:
  Number of finished trials:  20
  Number of pruned trials:  7
  Number of complete trials:  13
Best trial:
  Value:  0.82890625
  Params: 
    n_layers: 1
    n_units_l0: 73
    dropout_l0: 0.27826526915707817
    optimizer: Adam
    lr: 0.0033209042919099627

Could you please review?

cc: @not522 
