### PR TITLE
[hotfix] Fix Dask-ML example by adding the version constraint on numpy

### DIFF
--- a/.github/workflows/dask_ml.yml
+++ b/.github/workflows/dask_ml.yml
@@ -29,6 +29,8 @@ jobs:
         pip install git+https://github.com/optuna/optuna.git
         # TODO(c-bata): Remove the version constraint after dask-ml supports dask 2025.1.0
         pip install "dask<2025.1.0"
+        # TODO(c-bata): Remove the version constraint after fixes https://github.com/optuna/optuna-examples/issues/314
+        pip install "numpy<2.2"
         python -c 'import optuna'
 
         pip install -r dask_ml/requirements.txt


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
See https://github.com/optuna/optuna-examples/issues/314

## Description of the changes
<!-- Describe the changes in this PR. -->
The CI jobs related to Dask-ML started failing 4 days ago. According to the logs, the only difference appears to be the version of NumPy: one job uses NumPy 2.1.3, while the other uses NumPy 2.2.3.
