### PR TITLE
Remove version constraints of `tensorflow` and `numpy`

### DIFF
--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,5 +1,5 @@
 keras
 numpy
 optuna
-tensorflow-cpu<2.19.0
+tensorflow-cpu
 tensorflow-datasets

--- a/keras/requirements.txt
+++ b/keras/requirements.txt
@@ -1,5 +1,5 @@
 keras
-numpy<2.0.0  # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
+numpy
 optuna
-tensorflow-cpu<2.19.0  # TODO(y0z): remove the version constraint <2.19.0 after resolve the CI issue (cf. #304)
+tensorflow-cpu<2.19.0
 tensorflow-datasets

--- a/tensorflow/requirements.txt
+++ b/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow-estimator
-tensorflow-cpu>=2.11.0,<2.19.0  # TODO(y0z): remove the version constraint <2.19.0 after resolve the CI issue (cf. #304)
+tensorflow>=2.11
 tensorflow-datasets
 optuna

--- a/tensorflow/requirements.txt
+++ b/tensorflow/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow-estimator
-tensorflow>=2.11
+tensorflow-cpu>=2.11.0
 tensorflow-datasets
 optuna

--- a/tfkeras/requirements.txt
+++ b/tfkeras/requirements.txt
@@ -1,3 +1,3 @@
 optuna
-tensorflow-cpu<2.19.0  # TODO(y0z): remove the version constraint <2.19.0 after resolve the CI issue (cf. #304)
+tensorflow-cpu
 tensorflow-datasets


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Close #306.

## Description of the changes
<!-- Describe the changes in this PR. -->

Just revert https://github.com/optuna/optuna-examples/pull/304 and remove the numpy upper version constraint since we don't get errors anymore.