### PR TITLE
Add Spark example using ask-and-tell interface

### DIFF
--- a/spark/ask_and_tell_spark.py
+++ b/spark/ask_and_tell_spark.py
@@ -1,0 +1,41 @@
+"""
+Spark with Ask-and-Tell
+
+An example showing how to use Optuna's ask-and-tell interface with Apache Spark
+to distribute the evaluation of trials.
+
+This script uses PySpark's RDD to parallelize a simple quadratic function.
+"""
+
+import optuna
+
+try:
+    from pyspark.sql import SparkSession
+except ImportError:
+    SparkSession = None  # Allow running the script even if pyspark is not installed
+
+
+def evaluate(x):
+    return (x - 2) ** 2  # Simulate a trial evaluation on a Spark worker node
+
+
+if __name__ == "__main__":
+    if SparkSession is None:
+        print("This example requires pyspark. Please install it to run this script.")
+    else:
+        spark = SparkSession.builder.appName("OptunaSparkExample").getOrCreate()
+        study = optuna.create_study()
+        optuna.seed(42)
+
+        for i in range(20):
+            trial = study.ask()
+            x = trial.suggest_float("x", -10, 10)
+            rdd = spark.sparkContext.parallelize([x])
+            result = rdd.map(evaluate).collect()[0]
+            study.tell(trial, result)
+            print(f"Trial {i + 1}: x = {x:.4f}, result = {result:.4f}")
+
+        print("\nBest trial:")
+        print(f"  Value: {study.best_value}")
+        print(f"  Params: {study.best_trial.params}")
+        spark.stop()

--- a/spark/ask_and_tell_spark.py
+++ b/spark/ask_and_tell_spark.py
@@ -8,12 +8,7 @@ This script uses PySpark's RDD to parallelize a simple quadratic function.
 """
 
 import optuna
-
-
-try:
-    from pyspark.sql import SparkSession
-except ImportError:
-    SparkSession = None  # Allow running the script even if pyspark is not installed
+from pyspark.sql import SparkSession
 
 
 def evaluate(x):

--- a/spark/ask_and_tell_spark.py
+++ b/spark/ask_and_tell_spark.py
@@ -16,21 +16,18 @@ def evaluate(x):
 
 
 if __name__ == "__main__":
-    if SparkSession is None:
-        print("This example requires pyspark. Please install it to run this script.")
-    else:
-        spark = SparkSession.builder.appName("OptunaSparkExample").getOrCreate()
-        study = optuna.create_study()
+    spark = SparkSession.builder.appName("OptunaSparkExample").getOrCreate()
+    study = optuna.create_study()
 
-        for i in range(20):
-            trial = study.ask()
-            x = trial.suggest_float("x", -10, 10)
-            rdd = spark.sparkContext.parallelize([x])
-            result = rdd.map(evaluate).collect()[0]
-            study.tell(trial, result)
-            print(f"Trial {i + 1}: x = {x:.4f}, result = {result:.4f}")
+    for i in range(20):
+        trial = study.ask()
+        x = trial.suggest_float("x", -10, 10)
+        rdd = spark.sparkContext.parallelize([x])
+        result = rdd.map(evaluate).collect()[0]
+        study.tell(trial, result)
+        print(f"Trial#{trial.number}: {x=:.4e}, {result=:.4e}")
 
         print("\nBest trial:")
-        print(f"  Value: {study.best_value}")
-        print(f"  Params: {study.best_trial.params}")
+        print(f"\tValue: {study.best_value}")
+        print(f"\tParams: {study.best_trial.params}")
         spark.stop()

--- a/spark/ask_and_tell_spark.py
+++ b/spark/ask_and_tell_spark.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         study.tell(trial, result)
         print(f"Trial#{trial.number}: {x=:.4e}, {result=:.4e}")
 
-        print("\nBest trial:")
-        print(f"\tValue: {study.best_value}")
-        print(f"\tParams: {study.best_trial.params}")
-        spark.stop()
+    print("\nBest trial:")
+    print(f"\tValue: {study.best_value}")
+    print(f"\tParams: {study.best_trial.params}")
+    spark.stop()

--- a/spark/ask_and_tell_spark.py
+++ b/spark/ask_and_tell_spark.py
@@ -9,6 +9,7 @@ This script uses PySpark's RDD to parallelize a simple quadratic function.
 
 import optuna
 
+
 try:
     from pyspark.sql import SparkSession
 except ImportError:
@@ -25,7 +26,6 @@ if __name__ == "__main__":
     else:
         spark = SparkSession.builder.appName("OptunaSparkExample").getOrCreate()
         study = optuna.create_study()
-        optuna.seed(42)
 
         for i in range(20):
             trial = study.ask()

--- a/spark/requirements.txt
+++ b/spark/requirements.txt
@@ -1,0 +1,2 @@
+optuna
+pyspark  # used for SparkSession and RDD parallelism


### PR DESCRIPTION
## Overview

This PR adds an example that demonstrates how to use Optuna's ask-and-tell interface with Apache Spark to distribute trial evaluations in parallel using PySpark's RDD API.

The script defines a simple quadratic objective function and evaluates it across Spark worker nodes. It shows how ask-and-tell can be used with a distributed engine without requiring integration with external orchestrators.

## Motivation

The example is inspired by multiple user questions regarding Spark integration, as discussed in [optuna/optuna#6077](https://github.com/optuna/optuna/issues/6077). While the functionality already exists via `ask()` and `tell()`, this example provides a hands-on script for users working with Spark.

## Notes

- This script is placed in the `spark/` directory.
- Includes fallback if PySpark is not installed.
- Lightly formatted and runnable standalone (not Sphinx-bound).

Please let me know if you'd like the example adjusted further.
