### PR TITLE
Remove Version Constraint for Transformers

### DIFF
--- a/.github/workflows/transformers.yml
+++ b/.github/workflows/transformers.yml
@@ -30,8 +30,6 @@ jobs:
         pip install git+https://github.com/optuna/optuna.git
         python -c 'import optuna'
 
-        # TODO(c-bata): Remove the version constraint after fixes https://github.com/optuna/optuna-examples/issues/331
-        pip install "transformers<4.57.0"
         pip install -r transformers/requirements.txt
     - name: Run examples
       run: |


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fixes #331 

After the release of transformers `v4.57.1`, the version constraint can be safely removed. 

Also, I have contributed a recipe in the [HF Open-Source AI Cookbook](https://huggingface.co/learn/cookbook/en/optuna_hpo_with_transformers#hyperparameter-optimization-with-optuna-and-transformers) on an expanded version of this example as a complete end-to-end recipe. Could I please add a link for it in the tutorial docstring?

cc: @c-bata 

## Description of the changes
Remove version constraint of transformers.
