### PR TITLE
fix spark example

### DIFF
--- a/spark/ask_and_tell_spark.py
+++ b/spark/ask_and_tell_spark.py
@@ -32,9 +32,7 @@ if __name__ == "__main__":
         results = rdd.map(lambda x: evaluate(*x)).collect()
         for trial_number, result in results:
             study.tell(trial_number, result)
-        print(f"Batch: {batch}")
-        print(f"\tValue: {study.best_value}")
-        print(f"\tParams: {study.best_trial.params}")
+            print(f"Trial#{trial_number}: {result=:.4e}")
 
     print("\nBest trial:")
     print(f"\tValue: {study.best_value}")


### PR DESCRIPTION
## Motivation
The Spark example does not use Spark's parallelism but calculates one parameter at the time in Spark. The point of the ask-and-tell functionality is to calculate batches of parameters. This PR fixes (https://github.com/optuna/optuna-examples/issues/341)

## Description of the changes
In the script we now loop over batches and within each batch we calculate parameter candidates in parallel in Spark.
