### PR TITLE
Pin scikit-learn to < 1.6.0 for lightgbm

### DIFF
--- a/lightgbm/requirements.txt
+++ b/lightgbm/requirements.txt
@@ -1,5 +1,5 @@
 lightgbm>=3.3.0
 numpy
 optuna
-scikit-learn
+scikit-learn<1.6.0  # TODO(y0z:) Remove upper bound when lightgbm supports scikit-learn 1.6.0
 botorch


### PR DESCRIPTION
## Motivation
Fix the lightgbm CI.

## Description of the changes
In scikit-learn 1.6.0, `force_all_finite` has been renamed to `ensure_all_finite`. This causes an unknown argument error in the lightgbm CI. This PR fixes the error by pinning the scikit-learn version to < 1.6.0.


https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_X_y.html 
<img width="772" height="264" alt="image" src="https://github.com/user-attachments/assets/a1f0c0fb-69e3-44ea-84b2-3e3205bfd99a" />