### PR TITLE
Remove Neptune from External Projects List

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ If you are interested in defining a user-defined sampler, here is an example:
 * [CuPy](https://github.com/cupy/cupy)
 * [Hydra's Optuna Sweeper Plugin](https://hydra.cc/docs/next/plugins/optuna_sweeper/)
 * [Mozilla Voice STT](https://github.com/mozilla/DeepSpeech)
-* [neptune.ai](https://neptune.ai)
 * [OptGBM: A scikit-learn Compatible LightGBM Estimator with Optuna](https://github.com/Y-oHr-N/OptGBM)
 * [Optuna-distributed](https://github.com/xadrianzetx/optuna-distributed)
 * [PyKEEN](https://github.com/pykeen/pykeen)


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull requests after they get one or more approvals. -->

## Motivation
Due to the [acquisition](https://docs.neptune.ai/transition_hub/), the platform will not be available for customers soon, so we can remove it from the list. Could you please review?

## Description of the changes
<!-- Describe the changes in this PR. -->
